### PR TITLE
Modules refactor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,81 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [main, modules_refactor]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  stub-run:
+    name: Stub-run all scenarios
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Install Nextflow
+        run: |
+          curl -s https://get.nextflow.io | bash
+          sudo mv nextflow /usr/local/bin/
+          nextflow -version
+
+      - name: Stub-run — full (all toggles on)
+        run: |
+          nextflow run . \
+            -profile test \
+            -params-file tests/config/params_full.json \
+            -stub-run \
+            -ansi-log false
+          echo "Expected: 22 processes"
+
+      - name: Stub-run — toggles off
+        run: |
+          nextflow run . \
+            -profile test \
+            -params-file tests/config/params_toggles_off.json \
+            -stub-run \
+            -ansi-log false
+          echo "Expected: 18 processes"
+
+      - name: Stub-run — from_bam
+        run: |
+          nextflow run . \
+            -profile test \
+            -params-file tests/config/params_from_bam.json \
+            -stub-run \
+            -ansi-log false
+
+      - name: Stub-run — feedback
+        run: |
+          nextflow run . \
+            -profile test \
+            -params-file tests/config/params_feedback.json \
+            -stub-run \
+            -ansi-log false
+
+      - name: Module test — PAS_REFERENCE_BUILD (stub)
+        run: |
+          nextflow run tests/modules/apa/test_pas_reference_build.nf \
+            -stub \
+            -ansi-log false
+
+      - name: Upload Nextflow logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextflow-logs
+          path: |
+            .nextflow.log
+            work/
+          retention-days: 3

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 work/
 results/
 tests/results*/
+.nf_test_work/
 .pytest_cache/
 .mypy_cache/
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 work/
 results/
+tests/results*/
 .pytest_cache/
 .mypy_cache/
 *.pyc

--- a/bin/build_pas_reference.py
+++ b/bin/build_pas_reference.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+
+import argparse
+import csv
+import logging
+import re
+from collections import defaultdict
+from pathlib import Path
+
+
+REQUIRED_SITE_COLUMNS = {
+    "site_id",
+    "gene_id",
+    "chrom",
+    "start",
+    "end",
+    "strand",
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Build a contract-stable PAS reference from repo-native inputs."
+    )
+    parser.add_argument("--site-catalog", required=True)
+    parser.add_argument("--terminal-exons", required=True)
+    parser.add_argument("--known-polya", required=True)
+    parser.add_argument("--out-tsv", required=True)
+    parser.add_argument("--out-manifest", required=True)
+    parser.add_argument("--log", required=True)
+    parser.add_argument("--out-bed")
+    parser.add_argument("--merge-distance", type=int, default=25)
+    return parser.parse_args()
+
+
+def setup_logging(log_path: Path):
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[%(asctime)s] %(levelname)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+        handlers=[
+            logging.FileHandler(log_path, mode="w", encoding="utf-8"),
+            logging.StreamHandler(),
+        ],
+    )
+
+
+def is_missing_file(path: Path) -> bool:
+    return (not path.exists()) or path.name == "NO_FILE" or path.stat().st_size == 0
+
+
+def load_tsv_rows(path: Path):
+    if is_missing_file(path):
+        return []
+    with path.open("r", newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+def normalize_chrom(value: str) -> str:
+    chrom = str(value or "").strip()
+    if not chrom:
+        return chrom
+    if chrom in {"M", "MT"}:
+        return "chrM"
+    if chrom.startswith("chr"):
+        return chrom
+    return f"chr{chrom}"
+
+
+def safe_int(value, default=0):
+    if value is None:
+        return default
+    text = str(value).strip()
+    if not text:
+        return default
+    return int(float(text))
+
+
+def anchor_for_interval(start: int, end: int, strand: str) -> int:
+    return end if strand == "+" else start
+
+
+def normalize_site_catalog(path: Path):
+    rows = load_tsv_rows(path)
+    normalized = []
+    for row in rows:
+        if not REQUIRED_SITE_COLUMNS.issubset(row.keys()):
+            missing = sorted(REQUIRED_SITE_COLUMNS - set(row.keys()))
+            raise ValueError(f"site_catalog missing required columns: {missing}")
+        start = safe_int(row.get("start"))
+        end = safe_int(row.get("end"), start)
+        strand = (row.get("strand") or "+").strip() or "+"
+        normalized.append(
+            {
+                "gene_id": (row.get("gene_id") or "unknown_gene").strip(),
+                "chrom": normalize_chrom(row.get("chrom")),
+                "start": start,
+                "end": end,
+                "strand": strand,
+                "anchor": anchor_for_interval(start, end, strand),
+                "site_id": (row.get("site_id") or "").strip(),
+                "source_kind": "site_catalog",
+                "site_source": (row.get("site_source") or "site_catalog").strip(),
+            }
+        )
+    return normalized
+
+
+def normalize_terminal_exons(path: Path):
+    rows = load_tsv_rows(path)
+    normalized = []
+    for row in rows:
+        start = safe_int(row.get("start"))
+        end = safe_int(row.get("end"), start)
+        strand = (row.get("strand") or "+").strip() or "+"
+        anchor = anchor_for_interval(start, end, strand)
+        gene_id = (row.get("gene_id") or "unknown_gene").strip()
+        chrom = normalize_chrom(row.get("chrom"))
+        normalized.append(
+            {
+                "gene_id": gene_id,
+                "chrom": chrom,
+                "start": anchor,
+                "end": anchor,
+                "strand": strand,
+                "anchor": anchor,
+                "site_id": f"{gene_id}:{chrom}:{anchor}:{strand}",
+                "source_kind": "terminal_exon",
+                "site_source": "terminal_exon",
+            }
+        )
+    return normalized
+
+
+def normalize_known_polya(path: Path):
+    rows = load_tsv_rows(path)
+    normalized = []
+    for row in rows:
+        gene_id = (row.get("gene_id") or row.get("gene") or "unknown_gene").strip()
+        chrom = normalize_chrom(row.get("chrom") or row.get("chr"))
+        start = safe_int(row.get("start") or row.get("position") or row.get("end"))
+        end = safe_int(row.get("end") or row.get("position") or row.get("start"), start)
+        strand = (row.get("strand") or "+").strip() or "+"
+        anchor = anchor_for_interval(start, end, strand)
+        normalized.append(
+            {
+                "gene_id": gene_id,
+                "chrom": chrom,
+                "start": anchor,
+                "end": anchor,
+                "strand": strand,
+                "anchor": anchor,
+                "site_id": f"{gene_id}:{chrom}:{anchor}:{strand}",
+                "source_kind": "known_polya",
+                "site_source": "known_polya",
+            }
+        )
+    return normalized
+
+
+def representative_priority(row):
+    if row["source_kind"] == "site_catalog" and "atlas" in row["site_source"]:
+        return 0
+    if row["source_kind"] == "known_polya":
+        return 1
+    if row["source_kind"] == "site_catalog":
+        return 2
+    return 3
+
+
+def choose_representative(rows):
+    strand = rows[0]["strand"]
+    if strand == "+":
+        coord_key = lambda row: (row["anchor"], row["start"], row["end"])
+    else:
+        coord_key = lambda row: (-row["anchor"], -row["start"], -row["end"])
+    return sorted(rows, key=lambda row: (representative_priority(row), coord_key(row), row["site_id"]))[0]
+
+
+def cluster_candidates(candidates, merge_distance):
+    grouped = defaultdict(list)
+    for row in candidates:
+        key = (row["gene_id"], row["chrom"], row["strand"])
+        grouped[key].append(row)
+
+    clusters = []
+    for key in sorted(grouped):
+        rows = sorted(grouped[key], key=lambda row: row["anchor"])
+        current = []
+        for row in rows:
+            if not current:
+                current = [row]
+                continue
+            if abs(row["anchor"] - current[-1]["anchor"]) <= merge_distance:
+                current.append(row)
+            else:
+                clusters.append(current)
+                current = [row]
+        if current:
+            clusters.append(current)
+    return clusters
+
+
+def sanitize_token(text: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9]+", "_", text or "unknown")
+    return cleaned.strip("_") or "unknown"
+
+
+def build_reference_rows(site_catalog_rows, terminal_exon_rows, known_polya_rows, merge_distance):
+    candidates = site_catalog_rows + known_polya_rows + terminal_exon_rows
+    if not candidates:
+        return []
+
+    output_rows = []
+    for cluster in cluster_candidates(candidates, merge_distance):
+        rep = choose_representative(cluster)
+        anchor = rep["anchor"]
+        sources = sorted({row["source_kind"] for row in cluster})
+        source_label = "+".join(sources)
+        gene_token = sanitize_token(rep["gene_id"])
+        chrom_token = sanitize_token(rep["chrom"])
+        output_rows.append(
+            {
+                "pas_reference_id": f"pasref_{gene_token}_{chrom_token}_{anchor}_{rep['strand']}",
+                "site_id": rep["site_id"] or f"{rep['gene_id']}:{rep['chrom']}:{anchor}:{rep['strand']}",
+                "gene_id": rep["gene_id"],
+                "chrom": rep["chrom"],
+                "start": anchor,
+                "end": anchor,
+                "strand": rep["strand"],
+                "reference_source": source_label,
+            }
+        )
+
+    output_rows.sort(key=lambda row: (row["gene_id"], row["chrom"], row["start"], row["strand"]))
+    return output_rows
+
+
+def write_reference_rows(path: Path, rows):
+    fieldnames = [
+        "pas_reference_id",
+        "site_id",
+        "gene_id",
+        "chrom",
+        "start",
+        "end",
+        "strand",
+        "reference_source",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_bed(path: Path, rows):
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        for row in rows:
+            writer.writerow(
+                [
+                    row["chrom"],
+                    max(int(row["start"]) - 1, 0),
+                    row["end"],
+                    row["pas_reference_id"],
+                    0,
+                    row["strand"],
+                ]
+            )
+
+
+def write_manifest(path: Path, args, site_catalog_rows, terminal_exon_rows, known_polya_rows, output_rows):
+    manifest_rows = [
+        ("site_catalog", Path(args.site_catalog).name),
+        ("terminal_exons", Path(args.terminal_exons).name),
+        ("known_polya", Path(args.known_polya).name),
+        ("merge_distance", str(args.merge_distance)),
+        ("site_catalog_rows", str(len(site_catalog_rows))),
+        ("terminal_exon_rows", str(len(terminal_exon_rows))),
+        ("known_polya_rows", str(len(known_polya_rows))),
+        ("pas_reference_rows", str(len(output_rows))),
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle, delimiter="\t")
+        writer.writerow(["field", "value"])
+        writer.writerows(manifest_rows)
+
+
+def main():
+    args = parse_args()
+    log_path = Path(args.log)
+    setup_logging(log_path)
+
+    try:
+        site_catalog_path = Path(args.site_catalog)
+        terminal_exons_path = Path(args.terminal_exons)
+        known_polya_path = Path(args.known_polya)
+
+        logging.info("Loading PAS reference inputs")
+        site_catalog_rows = normalize_site_catalog(site_catalog_path)
+        terminal_exon_rows = normalize_terminal_exons(terminal_exons_path)
+        known_polya_rows = normalize_known_polya(known_polya_path)
+
+        logging.info(
+            "Loaded %s site_catalog rows, %s terminal_exon rows, %s known_polya rows",
+            len(site_catalog_rows),
+            len(terminal_exon_rows),
+            len(known_polya_rows),
+        )
+
+        output_rows = build_reference_rows(
+            site_catalog_rows,
+            terminal_exon_rows,
+            known_polya_rows,
+            args.merge_distance,
+        )
+
+        out_tsv = Path(args.out_tsv)
+        write_reference_rows(out_tsv, output_rows)
+        write_manifest(
+            Path(args.out_manifest),
+            args,
+            site_catalog_rows,
+            terminal_exon_rows,
+            known_polya_rows,
+            output_rows,
+        )
+
+        if args.out_bed:
+            write_bed(Path(args.out_bed), output_rows)
+
+        logging.info("Wrote %s PAS reference rows to %s", len(output_rows), out_tsv)
+    except Exception:
+        logging.exception("PAS reference construction failed")
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/conf/deepthought.config
+++ b/conf/deepthought.config
@@ -10,7 +10,10 @@
 // Override on a per-run basis with -work-dir if you want run-specific dirs.
 
 params {
-    outdir             = '/scratch/results/scPolASeq'
+    // outdir is intentionally NOT set here so per-dataset profiles
+    // (e.g. test_pbmc1k_deepthought) can set it without being overridden.
+    // If no profile sets outdir, it falls back to the nextflow.config default ('results').
+
     // Pre-built SIF cache: run  bash containers/build.sh  once to populate
     apptainer_cache_dir = '/scratch/cache/apptainer/scpolaseq'
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -24,7 +24,7 @@ from leaking tuple-layout assumptions across the pipeline.
 
 ## Contract strategy
 
-Current working outputs remain the primary public surface. New modules
-(`PAS_REFERENCE_BUILD`, `SIERRA_QUANT`, `PAS_SCORING`) are scaffolded as
-sidecars with explicit I/O so they can mature independently without breaking
-existing consumers.
+Current working outputs remain the primary public surface. `PAS_REFERENCE_BUILD`
+now has a repo-native implementation on top of the frozen input contract, while
+`SIERRA_QUANT` and `PAS_SCORING` remain scaffolded sidecars with explicit I/O so
+they can mature independently without breaking existing consumers.

--- a/docs/design.md
+++ b/docs/design.md
@@ -14,3 +14,17 @@
 ## Provenance strategy
 
 The scaffold emits manifest tables at alignment and labeling stages. These are meant to remain stable inputs to later `feedback` runs.
+
+## APA orchestration boundary
+
+`subworkflows/apa_core.nf` is the contract freezer for APA-stage execution. It
+owns channel reshaping, toggle handling, and future sidecar module wiring. This
+keeps `main.nf` focused on coarse orchestration and prevents later feature work
+from leaking tuple-layout assumptions across the pipeline.
+
+## Contract strategy
+
+Current working outputs remain the primary public surface. New modules
+(`PAS_REFERENCE_BUILD`, `SIERRA_QUANT`, `PAS_SCORING`) are scaffolded as
+sidecars with explicit I/O so they can mature independently without breaking
+existing consumers.

--- a/docs/module_contracts.md
+++ b/docs/module_contracts.md
@@ -34,10 +34,6 @@ apa_min_coverage                   // val(Integer)
 apa_min_pdui_delta                 // val(Decimal)
 apa_model_type                     // val(String)
 apa_model_group_level              // val(String)
-enable_single_cell_apa_projection  // val(Boolean)
-enable_pas_reference_build         // val(Boolean)
-enable_sierra_quant                // val(Boolean)
-enable_pas_scoring                 // val(Boolean)
 ```
 
 Primary emitted contracts:
@@ -193,6 +189,11 @@ path("pas_scoring.log")
 
 ## Toggle behavior
 
+- Toggle control is parameter-driven, not channel-driven:
+  `params.enable_single_cell_apa_projection`,
+  `params.enable_pas_reference_build`,
+  `params.enable_sierra_quant`,
+  `params.enable_pas_scoring`
 - `enable_pas_reference_build = false`
   `APA_CORE` falls back to the existing annotation-guided site catalog as the
   effective PAS reference.

--- a/docs/module_contracts.md
+++ b/docs/module_contracts.md
@@ -1,0 +1,202 @@
+# Module Contracts
+
+This document freezes the DSL2 contracts for the APA backbone. The goal is to
+keep orchestration stable even as biological logic evolves.
+
+## Naming conventions
+
+- `meta` is a Nextflow map with stable keys:
+  `sample_id`, `library_id`, `protocol`, `chemistry`, `condition`, `replicate_id`
+- `reference_bundle` is a tuple with fixed positional layout:
+  `tuple val(ref_meta), path(star_index), path(gtf), path(fasta), path(chrom_sizes), path(terminal_exons), path(site_catalog), path(priming_blacklist)`
+- Group-resolved files always carry both `group_level` and `group_id` in the channel contract, even if only one appears in the filename.
+- New scaffold stages are sidecar-only. They must not replace existing published APA outputs until explicitly promoted.
+
+## Subworkflow boundary
+
+### `APA_CORE`
+
+Purpose:
+connect barcode filtering, grouped BAM generation, coverage, APA feature calling,
+model scoring, and future PAS-oriented sidecar stages behind one orchestration
+surface.
+
+Input contract:
+
+```nextflow
+reference_bundle                   // tuple(ref_meta, star_index, gtf, fasta, chrom_sizes, terminal_exons, atlas, blacklist)
+bam_bundle                         // tuple val(meta), path(bam), path(bai)
+cell_annotations                   // path("cell_annotations.tsv")
+group_map                          // path("group_map.tsv")
+known_polya                        // path("*.tsv") or assets/NO_FILE
+apa_grouping_levels                // val("cluster,cell_type,...")
+apa_min_coverage                   // val(Integer)
+apa_min_pdui_delta                 // val(Decimal)
+apa_model_type                     // val(String)
+apa_model_group_level              // val(String)
+enable_single_cell_apa_projection  // val(Boolean)
+enable_pas_reference_build         // val(Boolean)
+enable_sierra_quant                // val(Boolean)
+enable_pas_scoring                 // val(Boolean)
+```
+
+Primary emitted contracts:
+
+```nextflow
+feature_table         = path("apa_features.tsv")
+apa_events            = path("apa_events.tsv")
+pdui_matrix           = path("pdui_usage_matrix.tsv")
+scored_events         = path("scored_apa_events.tsv")
+track_bundle          = path("*.bw")
+qc_bundle             = path("*.tsv")
+pas_reference         = path("pas_reference.tsv") | fallback path(site_catalog)
+sierra_quant          = tuple val(meta), val(group_level), val(group_id), path("*.sierra_quant.tsv")
+pas_scored_events     = path("pas_scored_events.tsv")
+```
+
+## Stable stage contracts
+
+### `BARCODE_FILTERING`
+
+```nextflow
+input:
+tuple val(meta), path(bam), path(bai)
+path("cell_annotations.tsv")
+
+output:
+tuple val(meta), path("*.bam"), path("*.bam.bai")
+path("*filter*.tsv")
+```
+
+Notes:
+`meta.library_id` remains the library-scoped identity anchor. Filtering must not
+rewrite sample identities.
+
+### `GROUPED_RECONSTRUCTION`
+
+```nextflow
+input:
+tuple val(meta), path(filtered_bam), path(filtered_bai)
+path("group_map.tsv")
+val(grouping_levels)
+
+output:
+tuple val(meta), val(group_level), path("*.grouped.bam"), path("*.grouped.bam.bai")
+path("*.grouping_manifest.tsv")
+```
+
+Notes:
+the output channel is library-scoped. One emission may contain multiple grouped
+BAM paths for the same `(meta, group_level)` pair.
+
+### `COVERAGE_GENERATION`
+
+```nextflow
+input:
+tuple val(meta), val(group_level), path("*.grouped.bam"), path("*.grouped.bam.bai")
+path("chrom.sizes")
+
+output:
+tuple val(meta), val(group_level), val(group_id), path("*.fwd.bedGraph"), path("*.rev.bedGraph")
+tuple val(meta), val(group_level), val(group_id), path("*.fwd.bw"),       path("*.rev.bw")
+path("*.coverage_stats.tsv")
+```
+
+Notes:
+strand-separated outputs are mandatory. Forward and reverse tracks travel as one
+logical contract unit.
+
+### `APA_FEATURE_PIPELINE`
+
+```nextflow
+input:
+path("site_catalog.tsv")
+tuple val(meta), val(group_level), val(group_id), path("*.fwd.bedGraph"), path("*.rev.bedGraph")
+path("cell_annotations.tsv")
+path("known_polya.tsv") | path("NO_FILE")
+val(min_coverage)
+val(min_pdui_delta)
+
+output:
+path("apa_features.tsv")
+path("apa_events.tsv")
+path("pdui_usage_matrix.tsv")
+```
+
+### `MODEL_PIPELINE`
+
+```nextflow
+input:
+path("apa_features.tsv")
+path("apa_events.tsv")
+val(model_type)
+val(group_level)
+val(enable_single_cell_projection)
+
+output:
+path("apa_model.pkl")
+path("feature_importance.tsv")
+path("model_metrics.tsv")
+path("scored_apa_events.tsv")
+```
+
+## Scaffold-only future modules
+
+### `PAS_REFERENCE_BUILD`
+
+```nextflow
+input:
+path("site_catalog.tsv")
+path("terminal_exons.tsv")
+path("known_polya.tsv") | path("NO_FILE")
+
+output:
+path("pas_reference.tsv")
+path("pas_reference_build.manifest.tsv")
+path("pas_reference_build.log")
+```
+
+Naming rule:
+the emitted file is always exactly `pas_reference.tsv`, independent of the
+source method.
+
+### `SIERRA_QUANT`
+
+```nextflow
+input:
+tuple val(meta), val(group_level), val(group_id), path("*.grouped.bam"), path("*.grouped.bam.bai"), path("pas_reference.tsv"), path("cell_annotations.tsv")
+
+output:
+tuple val(meta), val(group_level), val(group_id), path("*.sierra_quant.tsv")
+path("*.sierra_quant.manifest.tsv")
+path("*.sierra_quant.log")
+```
+
+Naming rule:
+`<library_id>.<group_level>.<group_id>.sierra_quant.tsv`
+
+### `PAS_SCORING`
+
+```nextflow
+input:
+path("apa_features.tsv")
+path("apa_events.tsv")
+path("pdui_usage_matrix.tsv")
+path("scored_apa_events.tsv")
+path("pas_reference.tsv")
+
+output:
+path("pas_scored_events.tsv")
+path("pas_scoring.manifest.tsv")
+path("pas_scoring.log")
+```
+
+## Toggle behavior
+
+- `enable_pas_reference_build = false`
+  `APA_CORE` falls back to the existing annotation-guided site catalog as the
+  effective PAS reference.
+- `enable_sierra_quant = false`
+  Sierra sidecar outputs emit an empty channel and do not affect legacy stages.
+- `enable_pas_scoring = false`
+  PAS scoring sidecar outputs emit an empty channel and do not affect reporting.

--- a/docs/module_contracts.md
+++ b/docs/module_contracts.md
@@ -10,7 +10,7 @@ keep orchestration stable even as biological logic evolves.
 - `reference_bundle` is a tuple with fixed positional layout:
   `tuple val(ref_meta), path(star_index), path(gtf), path(fasta), path(chrom_sizes), path(terminal_exons), path(site_catalog), path(priming_blacklist)`
 - Group-resolved files always carry both `group_level` and `group_id` in the channel contract, even if only one appears in the filename.
-- New scaffold stages are sidecar-only. They must not replace existing published APA outputs until explicitly promoted.
+- New PAS sidecar stages must not replace existing published APA outputs until explicitly promoted.
 
 ## Subworkflow boundary
 
@@ -136,7 +136,7 @@ path("model_metrics.tsv")
 path("scored_apa_events.tsv")
 ```
 
-## Scaffold-only future modules
+## PAS sidecar modules
 
 ### `PAS_REFERENCE_BUILD`
 
@@ -155,6 +155,10 @@ path("pas_reference_build.log")
 Naming rule:
 the emitted file is always exactly `pas_reference.tsv`, independent of the
 source method.
+
+Parameter control:
+`params.pas_reference_merge_distance` controls evidence collapsing without
+changing the channel contract.
 
 ### `SIERRA_QUANT`
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -32,6 +32,13 @@
 - `apa/gene_summary.tsv`
 - `apa/apa_stats.tsv`
 
+## PAS sidecars
+
+- `pas_reference/pas_reference.tsv`
+- `pas_reference/pas_reference_build.manifest.tsv`
+- `sierra_quant/<group_level>/<library_id>.<group_level>.<group_id>.sierra_quant.tsv`
+- `pas_scoring/pas_scored_events.tsv`
+
 ## Report
 
 - `report/scpolaseq_report.html`

--- a/main.nf
+++ b/main.nf
@@ -68,11 +68,7 @@ workflow SCPOLASEQ {
         params.apa_min_coverage ?: 5,
         params.apa_min_pdui_delta ?: 0.2,
         params.apa_model_type ?: 'random_forest',
-        params.apa_group_level ?: 'cluster',
-        params.enable_single_cell_apa_projection ?: false,
-        params.enable_pas_reference_build ?: true,
-        params.enable_sierra_quant ?: true,
-        params.enable_pas_scoring ?: true
+        params.apa_group_level ?: 'cluster'
     )
 
     // ── Reporting ─────────────────────────────────────────────────────────────

--- a/main.nf
+++ b/main.nf
@@ -6,12 +6,8 @@ include { REFERENCE_PREPARE      } from './subworkflows/local/reference_prepare/
 include { ALIGN_OR_IMPORT_SC     } from './subworkflows/local/alignment_or_import/main'
 include { CELL_LABELING_SC       } from './subworkflows/local/cell_labeling/main'
 
-// ── New 9-stage APA subworkflows ──────────────────────────────────────────────
-include { BARCODE_FILTERING      } from './subworkflows/local/barcode_filtering/main'
-include { GROUPED_RECONSTRUCTION } from './subworkflows/local/grouped_reconstruction/main'
-include { COVERAGE_GENERATION    } from './subworkflows/local/coverage_generation/main'
-include { APA_FEATURE_PIPELINE   } from './subworkflows/local/apa_feature_pipeline/main'
-include { MODEL_PIPELINE         } from './subworkflows/local/model_pipeline/main'
+// ── APA orchestration boundary ────────────────────────────────────────────────
+include { APA_CORE               } from './subworkflows/apa_core'
 
 // ── Reporting ─────────────────────────────────────────────────────────────────
 include { REPORTING_SC           } from './subworkflows/local/reporting/main'
@@ -55,79 +51,37 @@ workflow SCPOLASEQ {
         params.grouping_levels
     )
 
-    // ── Stage 3 — Barcode-aware BAM filtering ─────────────────────────────────
-    // Reads are subset to valid cell barcodes; each read is tagged with its
-    // cluster / cell_type derived from CELL_LABELING_SC.
-    BARCODE_FILTERING(
-        ALIGN_OR_IMPORT_SC.out.bam_bundle,
-        CELL_LABELING_SC.out.cell_annotations          // plain path (unified TSV)
-    )
-
-    // ── Stage 4 — Grouped BAM reconstruction (one BAM per group_level/group_id)
-    GROUPED_RECONSTRUCTION(
-        BARCODE_FILTERING.out.filtered_bam,
-        CELL_LABELING_SC.out.group_map,                // plain path
-        params.apa_grouping_levels ?: 'cluster,cell_type'
-    )
-
-    // ── Stage 5 — Strand-aware coverage tracks (bedGraph + bigWig) ───────────
-    // Extract chrom_sizes from the reference bundle (field index 4)
-    REFERENCE_PREPARE.out.reference_bundle
-        .map { ref_meta, star_index, gtf, fasta, chrom_sizes,
-               terminal_exons, atlas, blacklist -> chrom_sizes }
-        .first()
-        .set { ch_chrom_sizes }
-
-    COVERAGE_GENERATION(
-        GROUPED_RECONSTRUCTION.out.grouped_bams,
-        ch_chrom_sizes
-    )
-
-    // ── Stages 6 + 7 — APA feature extraction + statistical APA calling ───────
-    // site_catalog / atlas from reference bundle (field index 6)
-    REFERENCE_PREPARE.out.reference_bundle
-        .map { ref_meta, star_index, gtf, fasta, chrom_sizes,
-               terminal_exons, atlas, blacklist -> atlas }
-        .first()
-        .set { ch_site_catalog }
-
+    // ── Stages 3–9 — APA core orchestration ───────────────────────────────────
+    // All APA-stage channel wiring is isolated behind APA_CORE so future
+    // modules can be added without widening main.nf.
     def ch_known_polya = params.known_polya
         ? Channel.value(file(params.known_polya, checkIfExists: true))
-        : Channel.value(nofile)
+        : Channel.value(file("${projectDir}/assets/NO_FILE"))
 
-    APA_FEATURE_PIPELINE(
-        ch_site_catalog,
-        COVERAGE_GENERATION.out.bedgraphs,
+    APA_CORE(
+        REFERENCE_PREPARE.out.reference_bundle,
+        ALIGN_OR_IMPORT_SC.out.bam_bundle,
         CELL_LABELING_SC.out.cell_annotations,
+        CELL_LABELING_SC.out.group_map,
         ch_known_polya,
-        params.apa_min_coverage   ?: 5,
-        params.apa_min_pdui_delta ?: 0.2
-    )
-
-    // ── Stages 8 + 9 — ML model training + APA event scoring ─────────────────
-    MODEL_PIPELINE(
-        APA_FEATURE_PIPELINE.out.feature_table,
-        APA_FEATURE_PIPELINE.out.apa_events,
-        params.apa_model_type  ?: 'random_forest',
+        params.apa_grouping_levels ?: 'cluster,cell_type',
+        params.apa_min_coverage ?: 5,
+        params.apa_min_pdui_delta ?: 0.2,
+        params.apa_model_type ?: 'random_forest',
         params.apa_group_level ?: 'cluster',
-        params.enable_single_cell_apa_projection ?: false
+        params.enable_single_cell_apa_projection ?: false,
+        params.enable_pas_reference_build ?: true,
+        params.enable_sierra_quant ?: true,
+        params.enable_pas_scoring ?: true
     )
 
     // ── Reporting ─────────────────────────────────────────────────────────────
-    // Map bigwig tuples to flat paths for track_bundle; mix QC files for qc_bundle.
-    def ch_track_bundle = COVERAGE_GENERATION.out.bigwigs
-        .flatMap { meta, group_level, group_id, fwd_bw, rev_bw -> [fwd_bw, rev_bw] }
-
-    def ch_qc_bundle = BARCODE_FILTERING.out.filter_stats
-        .mix(MODEL_PIPELINE.out.model_metrics)
-        .mix(GROUPED_RECONSTRUCTION.out.grouping_manifest)
-
     REPORTING_SC(
-        APA_FEATURE_PIPELINE.out.feature_table,   // site_catalog proxy
-        APA_FEATURE_PIPELINE.out.pdui_matrix,     // apa_usage
-        MODEL_PIPELINE.out.scored_events,          // apa_stats
-        ch_track_bundle,
-        ch_qc_bundle
+        APA_CORE.out.feature_table,   // site_catalog proxy
+        APA_CORE.out.pdui_matrix,     // apa_usage
+        APA_CORE.out.scored_events,   // apa_stats
+        APA_CORE.out.track_bundle,
+        APA_CORE.out.qc_bundle
     )
 }
 

--- a/modules/local/alignment/starsolo_align_sc/main.nf
+++ b/modules/local/alignment/starsolo_align_sc/main.nf
@@ -23,28 +23,34 @@ process STARSOLO_ALIGN_SC {
     script:
     def whitelistArg = whitelist.name == 'NO_FILE' ? '--soloCBwhitelist None' : "--soloCBwhitelist ${whitelist}"
     def warning = protocol_mode == '10x_5p' ? "echo 'WARNING: guarded 10x 5p support is enabled; APA outputs are descriptive-first.' >&2" : ''
+    def readFilesCmd = reads[0].name.endsWith('.gz') ? '--readFilesCommand zcat' : ''
     """
     ${warning}
+    _star_ok=0
     if command -v STAR >/dev/null 2>&1; then
         STAR \\
             --genomeDir ${star_index} \\
             --sjdbGTFfile ${gtf} \\
             --readFilesIn ${reads[1]} ${reads[0]} \\
+            ${readFilesCmd} \\
             --runThreadN ${task.cpus} \\
             --outFileNamePrefix ${meta.library_id}. \\
             ${whitelistArg} \\
-            ${task.ext.args ?: ''} || true
+            ${task.ext.args ?: ''} && _star_ok=1
     fi
 
+    # Fallback placeholders — only if STAR was absent or failed
     mkdir -p ${meta.library_id}.Solo.out/Gene
-    touch ${meta.library_id}.Log.final.out
-    touch ${meta.library_id}.Aligned.sortedByCoord.out.bam
-    echo "${meta.sample_id}-CELL001" > ${meta.library_id}.Solo.out/Gene/barcodes.tsv
-    touch ${meta.library_id}.Solo.out/Gene/matrix.mtx
-    touch ${meta.library_id}.Solo.out/Gene/features.tsv
+    if [[ \$_star_ok -eq 0 ]]; then
+        touch ${meta.library_id}.Log.final.out
+        touch ${meta.library_id}.Aligned.sortedByCoord.out.bam
+        echo "${meta.sample_id}-CELL001" > ${meta.library_id}.Solo.out/Gene/barcodes.tsv
+        touch ${meta.library_id}.Solo.out/Gene/matrix.mtx
+        touch ${meta.library_id}.Solo.out/Gene/features.tsv
+    fi
 
-    if command -v samtools >/dev/null 2>&1; then
-        samtools index ${meta.library_id}.Aligned.sortedByCoord.out.bam || touch ${meta.library_id}.Aligned.sortedByCoord.out.bam.bai
+    if command -v samtools >/dev/null 2>&1 && [[ -s ${meta.library_id}.Aligned.sortedByCoord.out.bam ]]; then
+        samtools index ${meta.library_id}.Aligned.sortedByCoord.out.bam
     else
         touch ${meta.library_id}.Aligned.sortedByCoord.out.bam.bai
     fi

--- a/modules/local/apa/pas_reference_build/main.nf
+++ b/modules/local/apa/pas_reference_build/main.nf
@@ -45,7 +45,13 @@ process PAS_REFERENCE_BUILD {
     """
     printf "pas_reference_id\\tsite_id\\tgene_id\\tchrom\\tstart\\tend\\tstrand\\treference_source\\n" > pas_reference.tsv
     printf "pas_ref_stub_001\\tNA\\tNA\\tNA\\t0\\t0\\t+\\tstub\\n" >> pas_reference.tsv
-    printf "field\\tvalue\\nmode\\tstub\\n" > pas_reference_build.manifest.tsv
+
+    printf "field\\tvalue\\n" > pas_reference_build.manifest.tsv
+    printf "site_catalog\\t${site_catalog.name}\\n"   >> pas_reference_build.manifest.tsv
+    printf "terminal_exons\\t${terminal_exons.name}\\n" >> pas_reference_build.manifest.tsv
+    printf "known_polya\\t${known_polya.name}\\n"     >> pas_reference_build.manifest.tsv
+    printf "mode\\tstub\\n"                           >> pas_reference_build.manifest.tsv
+
     printf "PAS_REFERENCE_BUILD stub executed\\n" > pas_reference_build.log
     """
 }

--- a/modules/local/apa/pas_reference_build/main.nf
+++ b/modules/local/apa/pas_reference_build/main.nf
@@ -1,5 +1,5 @@
 /*
- * Scaffold-only PAS reference builder.
+ * PAS reference builder.
  *
  * Contract:
  *   input:
@@ -14,7 +14,10 @@
 process PAS_REFERENCE_BUILD {
     tag "pas_reference_build"
     label 'process_single'
+    label 'process_python'
 
+    conda "${projectDir}/envs/python.yml"
+    container params.apptainer_cache_dir ? "${params.apptainer_cache_dir}/scpolaseq-python.sif" : null
     publishDir "${params.outdir}/pas_reference", mode: params.publish_dir_mode
 
     input:
@@ -29,16 +32,14 @@ process PAS_REFERENCE_BUILD {
 
     script:
     """
-    printf "pas_reference_id\\tsite_id\\tgene_id\\tchrom\\tstart\\tend\\tstrand\\treference_source\\n" > pas_reference.tsv
-    printf "pas_ref_stub_001\\tNA\\tNA\\tNA\\t0\\t0\\t+\\tcontract_scaffold\\n" >> pas_reference.tsv
-
-    printf "field\\tvalue\\n" > pas_reference_build.manifest.tsv
-    printf "site_catalog\\t%s\\n" "${site_catalog.name}" >> pas_reference_build.manifest.tsv
-    printf "terminal_exons\\t%s\\n" "${terminal_exons.name}" >> pas_reference_build.manifest.tsv
-    printf "known_polya\\t%s\\n" "${known_polya.name}" >> pas_reference_build.manifest.tsv
-    printf "mode\\tscaffold_only\\n" >> pas_reference_build.manifest.tsv
-
-    printf "PAS_REFERENCE_BUILD scaffold executed\\n" > pas_reference_build.log
+    python ${projectDir}/bin/build_pas_reference.py \\
+        --site-catalog ${site_catalog} \\
+        --terminal-exons ${terminal_exons} \\
+        --known-polya ${known_polya} \\
+        --out-tsv pas_reference.tsv \\
+        --out-manifest pas_reference_build.manifest.tsv \\
+        --log pas_reference_build.log \\
+        --merge-distance ${params.pas_reference_merge_distance ?: 25}
     """
 
     stub:

--- a/modules/local/apa/pas_reference_build/main.nf
+++ b/modules/local/apa/pas_reference_build/main.nf
@@ -1,0 +1,51 @@
+/*
+ * Scaffold-only PAS reference builder.
+ *
+ * Contract:
+ *   input:
+ *     path site_catalog
+ *     path terminal_exons
+ *     path known_polya
+ *   output:
+ *     path "pas_reference.tsv"
+ *     path "pas_reference_build.manifest.tsv"
+ *     path "pas_reference_build.log"
+ */
+process PAS_REFERENCE_BUILD {
+    tag "pas_reference_build"
+    label 'process_single'
+
+    publishDir "${params.outdir}/pas_reference", mode: params.publish_dir_mode
+
+    input:
+    path site_catalog
+    path terminal_exons
+    path known_polya
+
+    output:
+    path "pas_reference.tsv",                emit: pas_reference
+    path "pas_reference_build.manifest.tsv", emit: manifest
+    path "pas_reference_build.log",          emit: log
+
+    script:
+    """
+    printf "pas_reference_id\\tsite_id\\tgene_id\\tchrom\\tstart\\tend\\tstrand\\treference_source\\n" > pas_reference.tsv
+    printf "pas_ref_stub_001\\tNA\\tNA\\tNA\\t0\\t0\\t+\\tcontract_scaffold\\n" >> pas_reference.tsv
+
+    printf "field\\tvalue\\n" > pas_reference_build.manifest.tsv
+    printf "site_catalog\\t%s\\n" "${site_catalog.name}" >> pas_reference_build.manifest.tsv
+    printf "terminal_exons\\t%s\\n" "${terminal_exons.name}" >> pas_reference_build.manifest.tsv
+    printf "known_polya\\t%s\\n" "${known_polya.name}" >> pas_reference_build.manifest.tsv
+    printf "mode\\tscaffold_only\\n" >> pas_reference_build.manifest.tsv
+
+    printf "PAS_REFERENCE_BUILD scaffold executed\\n" > pas_reference_build.log
+    """
+
+    stub:
+    """
+    printf "pas_reference_id\\tsite_id\\tgene_id\\tchrom\\tstart\\tend\\tstrand\\treference_source\\n" > pas_reference.tsv
+    printf "pas_ref_stub_001\\tNA\\tNA\\tNA\\t0\\t0\\t+\\tstub\\n" >> pas_reference.tsv
+    printf "field\\tvalue\\nmode\\tstub\\n" > pas_reference_build.manifest.tsv
+    printf "PAS_REFERENCE_BUILD stub executed\\n" > pas_reference_build.log
+    """
+}

--- a/modules/local/apa/pas_scoring/main.nf
+++ b/modules/local/apa/pas_scoring/main.nf
@@ -1,0 +1,56 @@
+/*
+ * Scaffold-only PAS scoring module.
+ *
+ * Contract:
+ *   input:
+ *     path feature_table
+ *     path apa_events
+ *     path pdui_matrix
+ *     path scored_events
+ *     path pas_reference
+ *   output:
+ *     path "pas_scored_events.tsv"
+ *     path "pas_scoring.manifest.tsv"
+ *     path "pas_scoring.log"
+ */
+process PAS_SCORING {
+    tag "pas_scoring"
+    label 'process_single'
+
+    publishDir "${params.outdir}/pas_scoring", mode: params.publish_dir_mode
+
+    input:
+    path feature_table
+    path apa_events
+    path pdui_matrix
+    path scored_events
+    path pas_reference
+
+    output:
+    path "pas_scored_events.tsv",    emit: scored_pas
+    path "pas_scoring.manifest.tsv", emit: manifest
+    path "pas_scoring.log",          emit: log
+
+    script:
+    """
+    printf "event_id\\tscore_namespace\\tscore_source\\treference_input\\n" > pas_scored_events.tsv
+    printf "stub_event_001\\tpas_scoring\\tscaffold_only\\t${pas_reference.name}\\n" >> pas_scored_events.tsv
+
+    printf "field\\tvalue\\n" > pas_scoring.manifest.tsv
+    printf "feature_table\\t%s\\n" "${feature_table.name}" >> pas_scoring.manifest.tsv
+    printf "apa_events\\t%s\\n" "${apa_events.name}" >> pas_scoring.manifest.tsv
+    printf "pdui_matrix\\t%s\\n" "${pdui_matrix.name}" >> pas_scoring.manifest.tsv
+    printf "scored_events\\t%s\\n" "${scored_events.name}" >> pas_scoring.manifest.tsv
+    printf "pas_reference\\t%s\\n" "${pas_reference.name}" >> pas_scoring.manifest.tsv
+
+    printf "PAS_SCORING scaffold executed\\n" > pas_scoring.log
+    """
+
+    stub:
+    """
+    printf "event_id\\tscore_namespace\\tscore_source\\treference_input\\n" > pas_scored_events.tsv
+    printf "stub_event_001\\tpas_scoring\\tstub\\tstub\\n" >> pas_scored_events.tsv
+    printf "field\\tvalue\\nmode\\tstub\\n" > pas_scoring.manifest.tsv
+    printf "PAS_SCORING stub executed\\n" > pas_scoring.log
+    """
+}

--- a/modules/local/apa/sierra_quant/main.nf
+++ b/modules/local/apa/sierra_quant/main.nf
@@ -1,0 +1,47 @@
+/*
+ * Scaffold-only Sierra quantification module.
+ *
+ * Contract:
+ *   input:
+ *     tuple val(meta), val(group_level), val(group_id), path(grouped_bam), path(grouped_bai), path(pas_reference), path(cell_annotations)
+ *   output:
+ *     tuple val(meta), val(group_level), val(group_id), path("<library>.<group_level>.<group_id>.sierra_quant.tsv")
+ *     path "<library>.<group_level>.<group_id>.sierra_quant.manifest.tsv"
+ *     path "<library>.<group_level>.<group_id>.sierra_quant.log"
+ */
+process SIERRA_QUANT {
+    tag "${meta.library_id}:${group_level}:${group_id}"
+    label 'process_single'
+
+    publishDir "${params.outdir}/sierra_quant/${group_level}", mode: params.publish_dir_mode
+
+    input:
+    tuple val(meta), val(group_level), val(group_id), path(grouped_bam), path(grouped_bai), path(pas_reference), path(cell_annotations)
+
+    output:
+    tuple val(meta), val(group_level), val(group_id), path("${meta.library_id}.${group_level}.${group_id}.sierra_quant.tsv"), emit: quantified_pas
+    path "${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv", emit: manifest
+    path "${meta.library_id}.${group_level}.${group_id}.sierra_quant.log", emit: log
+
+    script:
+    """
+    printf "library_id\\tgroup_level\\tgroup_id\\tpas_reference\\tquant_source\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.tsv
+    printf "${meta.library_id}\\t${group_level}\\t${group_id}\\t${pas_reference.name}\\tscaffold_only\\n" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.tsv
+
+    printf "field\\tvalue\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
+    printf "grouped_bam\\t%s\\n" "${grouped_bam.name}" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
+    printf "grouped_bai\\t%s\\n" "${grouped_bai.name}" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
+    printf "pas_reference\\t%s\\n" "${pas_reference.name}" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
+    printf "cell_annotations\\t%s\\n" "${cell_annotations.name}" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
+
+    printf "SIERRA_QUANT scaffold executed\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.log
+    """
+
+    stub:
+    """
+    printf "library_id\\tgroup_level\\tgroup_id\\tpas_reference\\tquant_source\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.tsv
+    printf "${meta.library_id}\\t${group_level}\\t${group_id}\\tstub\\tstub\\n" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.tsv
+    printf "field\\tvalue\\nmode\\tstub\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
+    printf "SIERRA_QUANT stub executed\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.log
+    """
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,6 +37,7 @@ params {
     apa_grouping_levels               = 'cluster,cell_type'  // comma-separated group levels
     apa_group_level                   = 'cluster' // primary level used for ML training/prediction
     enable_pas_reference_build        = true      // scaffold stage: build a contract-stable PAS reference artifact
+    pas_reference_merge_distance      = 25        // bp distance used when collapsing PAS evidence into one reference site
     enable_sierra_quant               = true      // scaffold stage: emit Sierra-compatible quant tables
     enable_pas_scoring                = true      // scaffold stage: emit PAS scoring sidecar outputs
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,6 +36,9 @@ params {
     apa_min_pdui_delta                = 0.2       // |ΔPDUI| threshold for APA significance
     apa_grouping_levels               = 'cluster,cell_type'  // comma-separated group levels
     apa_group_level                   = 'cluster' // primary level used for ML training/prediction
+    enable_pas_reference_build        = true      // scaffold stage: build a contract-stable PAS reference artifact
+    enable_sierra_quant               = true      // scaffold stage: emit Sierra-compatible quant tables
+    enable_pas_scoring                = true      // scaffold stage: emit PAS scoring sidecar outputs
 
     // ── ML model parameters ───────────────────────────────────────────────────
     apa_model_type                    = 'random_forest'  // 'random_forest'|'xgboost'|'logistic_regression'

--- a/schemas/table_contracts.md
+++ b/schemas/table_contracts.md
@@ -23,3 +23,15 @@
 ## apa_stats.tsv
 
 `contrast_id,gene_id,site_id,group_level,logFC,delta_usage,pvalue,fdr,test_class`
+
+## pas_reference.tsv
+
+`pas_reference_id,site_id,gene_id,chrom,start,end,strand,reference_source`
+
+## sierra_quant.tsv
+
+`library_id,group_level,group_id,pas_reference,quant_source`
+
+## pas_scored_events.tsv
+
+`event_id,score_namespace,score_source,reference_input`

--- a/subworkflows/apa_core.nf
+++ b/subworkflows/apa_core.nf
@@ -1,0 +1,178 @@
+/*
+ * APA core orchestration boundary.
+ *
+ * This subworkflow freezes the stage-3+ contract surface so new APA methods can
+ * plug in as sidecar modules without changing main.nf or the legacy outputs
+ * that downstream users already consume.
+ */
+include { BARCODE_FILTERING      } from './local/barcode_filtering/main'
+include { GROUPED_RECONSTRUCTION } from './local/grouped_reconstruction/main'
+include { COVERAGE_GENERATION    } from './local/coverage_generation/main'
+include { APA_FEATURE_PIPELINE   } from './local/apa_feature_pipeline/main'
+include { MODEL_PIPELINE         } from './local/model_pipeline/main'
+include { PAS_REFERENCE_BUILD    } from '../modules/local/apa/pas_reference_build/main'
+include { SIERRA_QUANT           } from '../modules/local/apa/sierra_quant/main'
+include { PAS_SCORING            } from '../modules/local/apa/pas_scoring/main'
+
+workflow APA_CORE {
+    take:
+    reference_bundle                   // tuple(ref_meta, star_index, gtf, fasta, chrom_sizes, terminal_exons, atlas, blacklist)
+    bam_bundle                         // tuple(meta, bam, bai)
+    cell_annotations                   // path: unified cell annotations TSV
+    group_map                          // path: barcode-to-group map TSV
+    known_polya                        // path: known PAS table or assets/NO_FILE sentinel
+    apa_grouping_levels                // val: comma-separated grouping levels
+    apa_min_coverage                   // val: minimum coverage threshold for APA calling
+    apa_min_pdui_delta                 // val: minimum |delta PDUI| threshold
+    apa_model_type                     // val: model type selector
+    apa_model_group_level              // val: group level used by training and prediction
+    enable_single_cell_apa_projection  // val: boolean toggle
+    enable_pas_reference_build         // val: boolean toggle
+    enable_sierra_quant                // val: boolean toggle
+    enable_pas_scoring                 // val: boolean toggle
+
+    main:
+    // Freeze the reference tuple layout here so downstream modules never index
+    // into the bundle ad hoc.
+    reference_bundle
+        .map { ref_meta, star_index, gtf, fasta, chrom_sizes, terminal_exons, atlas, blacklist -> chrom_sizes }
+        .first()
+        .set { ch_chrom_sizes }
+
+    reference_bundle
+        .map { ref_meta, star_index, gtf, fasta, chrom_sizes, terminal_exons, atlas, blacklist -> terminal_exons }
+        .first()
+        .set { ch_terminal_exons }
+
+    reference_bundle
+        .map { ref_meta, star_index, gtf, fasta, chrom_sizes, terminal_exons, atlas, blacklist -> atlas }
+        .first()
+        .set { ch_site_catalog }
+
+    BARCODE_FILTERING(
+        bam_bundle,
+        cell_annotations
+    )
+
+    GROUPED_RECONSTRUCTION(
+        BARCODE_FILTERING.out.filtered_bam,
+        group_map,
+        apa_grouping_levels
+    )
+
+    COVERAGE_GENERATION(
+        GROUPED_RECONSTRUCTION.out.grouped_bams,
+        ch_chrom_sizes
+    )
+
+    APA_FEATURE_PIPELINE(
+        ch_site_catalog,
+        COVERAGE_GENERATION.out.bedgraphs,
+        cell_annotations,
+        known_polya,
+        apa_min_coverage,
+        apa_min_pdui_delta
+    )
+
+    MODEL_PIPELINE(
+        APA_FEATURE_PIPELINE.out.feature_table,
+        APA_FEATURE_PIPELINE.out.apa_events,
+        apa_model_type,
+        apa_model_group_level,
+        enable_single_cell_apa_projection
+    )
+
+    def ch_pas_reference
+    def ch_pas_reference_manifest
+    if (enable_pas_reference_build) {
+        PAS_REFERENCE_BUILD(
+            ch_site_catalog,
+            ch_terminal_exons,
+            known_polya
+        )
+        ch_pas_reference = PAS_REFERENCE_BUILD.out.pas_reference
+        ch_pas_reference_manifest = PAS_REFERENCE_BUILD.out.manifest
+    } else {
+        // Disabled mode still emits a stable effective PAS reference by falling
+        // back to the annotation-guided site catalog already used today.
+        ch_pas_reference = ch_site_catalog
+        ch_pas_reference_manifest = Channel.empty()
+    }
+
+    def ch_sierra_quant
+    def ch_sierra_manifest
+    if (enable_sierra_quant) {
+        GROUPED_RECONSTRUCTION.out.grouped_bams
+            .flatMap { meta, group_level, bams, bais ->
+                def bam_list = (bams instanceof List) ? bams : [bams]
+                def bai_list = (bais instanceof List) ? bais : [bais]
+                [bam_list, bai_list].transpose().collect { bam, bai ->
+                    def group_id = bam.baseName.replaceAll(/\.grouped(\.bam)?$/, '')
+                    tuple(meta, group_level, group_id, bam, bai)
+                }
+            }
+            .combine(ch_pas_reference)
+            .combine(cell_annotations)
+            .map { meta, group_level, group_id, bam, bai, pas_reference, annotations ->
+                tuple(meta, group_level, group_id, bam, bai, pas_reference, annotations)
+            }
+            .set { ch_sierra_input }
+
+        SIERRA_QUANT(ch_sierra_input)
+        ch_sierra_quant = SIERRA_QUANT.out.quantified_pas
+        ch_sierra_manifest = SIERRA_QUANT.out.manifest
+    } else {
+        ch_sierra_quant = Channel.empty()
+        ch_sierra_manifest = Channel.empty()
+    }
+
+    def ch_pas_scored
+    def ch_pas_scoring_manifest
+    if (enable_pas_scoring) {
+        PAS_SCORING(
+            APA_FEATURE_PIPELINE.out.feature_table,
+            APA_FEATURE_PIPELINE.out.apa_events,
+            APA_FEATURE_PIPELINE.out.pdui_matrix,
+            MODEL_PIPELINE.out.scored_events,
+            ch_pas_reference
+        )
+        ch_pas_scored = PAS_SCORING.out.scored_pas
+        ch_pas_scoring_manifest = PAS_SCORING.out.manifest
+    } else {
+        ch_pas_scored = Channel.empty()
+        ch_pas_scoring_manifest = Channel.empty()
+    }
+
+    def ch_track_bundle = COVERAGE_GENERATION.out.bigwigs
+        .flatMap { meta, group_level, group_id, fwd_bw, rev_bw -> [fwd_bw, rev_bw] }
+
+    // Keep the reporting QC surface backward compatible; new sidecar manifests
+    // are emitted separately so they can be adopted intentionally later.
+    def ch_qc_bundle = BARCODE_FILTERING.out.filter_stats
+        .mix(MODEL_PIPELINE.out.model_metrics)
+        .mix(GROUPED_RECONSTRUCTION.out.grouping_manifest)
+
+    emit:
+    filtered_bam                = BARCODE_FILTERING.out.filtered_bam
+    filter_stats                = BARCODE_FILTERING.out.filter_stats
+    grouped_bams                = GROUPED_RECONSTRUCTION.out.grouped_bams
+    grouping_manifest           = GROUPED_RECONSTRUCTION.out.grouping_manifest
+    bedgraphs                   = COVERAGE_GENERATION.out.bedgraphs
+    bigwigs                     = COVERAGE_GENERATION.out.bigwigs
+    coverage_stats              = COVERAGE_GENERATION.out.coverage_stats
+    feature_table               = APA_FEATURE_PIPELINE.out.feature_table
+    apa_events                  = APA_FEATURE_PIPELINE.out.apa_events
+    pdui_matrix                 = APA_FEATURE_PIPELINE.out.pdui_matrix
+    trained_model               = MODEL_PIPELINE.out.trained_model
+    feature_importance          = MODEL_PIPELINE.out.feature_importance
+    model_metrics               = MODEL_PIPELINE.out.model_metrics
+    scored_events               = MODEL_PIPELINE.out.scored_events
+    pas_reference               = ch_pas_reference
+    pas_reference_manifest      = ch_pas_reference_manifest
+    sierra_quant                = ch_sierra_quant
+    sierra_manifest             = ch_sierra_manifest
+    pas_scored_events           = ch_pas_scored
+    pas_scoring_manifest        = ch_pas_scoring_manifest
+    track_bundle                = ch_track_bundle
+    qc_bundle                   = ch_qc_bundle
+}

--- a/subworkflows/apa_core.nf
+++ b/subworkflows/apa_core.nf
@@ -26,12 +26,13 @@ workflow APA_CORE {
     apa_min_pdui_delta                 // val: minimum |delta PDUI| threshold
     apa_model_type                     // val: model type selector
     apa_model_group_level              // val: group level used by training and prediction
-    enable_single_cell_apa_projection  // val: boolean toggle
-    enable_pas_reference_build         // val: boolean toggle
-    enable_sierra_quant                // val: boolean toggle
-    enable_pas_scoring                 // val: boolean toggle
 
     main:
+    def do_single_cell_projection = params.enable_single_cell_apa_projection.toString().toBoolean()
+    def do_pas_reference_build = params.enable_pas_reference_build.toString().toBoolean()
+    def do_sierra_quant = params.enable_sierra_quant.toString().toBoolean()
+    def do_pas_scoring = params.enable_pas_scoring.toString().toBoolean()
+
     // Freeze the reference tuple layout here so downstream modules never index
     // into the bundle ad hoc.
     reference_bundle
@@ -79,12 +80,12 @@ workflow APA_CORE {
         APA_FEATURE_PIPELINE.out.apa_events,
         apa_model_type,
         apa_model_group_level,
-        enable_single_cell_apa_projection
+        do_single_cell_projection
     )
 
     def ch_pas_reference
     def ch_pas_reference_manifest
-    if (enable_pas_reference_build) {
+    if (do_pas_reference_build) {
         PAS_REFERENCE_BUILD(
             ch_site_catalog,
             ch_terminal_exons,
@@ -101,7 +102,7 @@ workflow APA_CORE {
 
     def ch_sierra_quant
     def ch_sierra_manifest
-    if (enable_sierra_quant) {
+    if (do_sierra_quant) {
         GROUPED_RECONSTRUCTION.out.grouped_bams
             .flatMap { meta, group_level, bams, bais ->
                 def bam_list = (bams instanceof List) ? bams : [bams]
@@ -128,7 +129,7 @@ workflow APA_CORE {
 
     def ch_pas_scored
     def ch_pas_scoring_manifest
-    if (enable_pas_scoring) {
+    if (do_pas_scoring) {
         PAS_SCORING(
             APA_FEATURE_PIPELINE.out.feature_table,
             APA_FEATURE_PIPELINE.out.apa_events,

--- a/subworkflows/apa_core.nf
+++ b/subworkflows/apa_core.nf
@@ -152,6 +152,7 @@ workflow APA_CORE {
     def ch_qc_bundle = BARCODE_FILTERING.out.filter_stats
         .mix(MODEL_PIPELINE.out.model_metrics)
         .mix(GROUPED_RECONSTRUCTION.out.grouping_manifest)
+        .mix(ch_pas_reference_manifest)
 
     emit:
     filtered_bam                = BARCODE_FILTERING.out.filtered_bam

--- a/tests/config/params_toggles_off.json
+++ b/tests/config/params_toggles_off.json
@@ -1,0 +1,18 @@
+{
+  "input": "tests/data/samplesheet.csv",
+  "genome_fasta": "tests/data/reference.fa",
+  "gtf": "tests/data/reference.gtf",
+  "known_polya": "tests/data/known_polya.tsv",
+  "priming_blacklist": "tests/data/priming_blacklist.bed",
+  "cell_metadata": "tests/data/cell_metadata.tsv",
+  "run_mode": "full",
+  "aligner": "starsolo",
+  "protocol_mode": "10x_3p",
+  "emit_group_bams": false,
+  "emit_bigwigs": true,
+  "outdir": "tests/results/toggles_off",
+  "enable_pas_reference_build": false,
+  "enable_sierra_quant": false,
+  "enable_pas_scoring": false,
+  "enable_single_cell_apa_projection": false
+}

--- a/tests/data/site_catalog.tsv
+++ b/tests/data/site_catalog.tsv
@@ -1,0 +1,3 @@
+site_id	gene_id	chrom	start	end	strand	site_class	site_source	priming_flag
+geneA:chr1:120:+	geneA	chr1	120	120	+	known_pas	annotation+atlas	pass
+geneB:chr1:180:+	geneB	chr1	180	180	+	annotated_terminal_end	annotation	pass

--- a/tests/data/terminal_exons.tsv
+++ b/tests/data/terminal_exons.tsv
@@ -1,0 +1,3 @@
+gene_id	transcript_id	chrom	start	end	strand	exon_number	terminal_exon_rank
+geneA	tx1	chr1	61	120	+	2	1
+geneB	tx2	chr1	121	180	+	1	1

--- a/tests/modules/apa/test_pas_reference_build.nf
+++ b/tests/modules/apa/test_pas_reference_build.nf
@@ -9,7 +9,7 @@
  *   is wired in as the real implementation.
  *
  * Usage (stub — fast, no real tools needed):
- *   nextflow run tests/modules/apa/test_pas_reference_build.nf -stub
+ *   nextflow run tests/modules/apa/test_pas_reference_build.nf -stub-run
  *
  * Usage (real — exercises the actual script):
  *   nextflow run tests/modules/apa/test_pas_reference_build.nf
@@ -28,10 +28,9 @@ params.publish_dir_mode = 'copy'
 // ── Test fixtures (reuse workflow test data) ─────────────────────────────────
 // launchDir = directory from which `nextflow run` was called (repo root).
 // projectDir = directory containing this script (tests/modules/apa/).
-// NOTE: use distinct files for each input to avoid Nextflow filename collision.
-def SITE_CATALOG   = file("${launchDir}/tests/data/known_polya.tsv",       checkIfExists: true)
-def TERMINAL_EXONS = file("${launchDir}/tests/data/priming_blacklist.bed",  checkIfExists: true)
-def KNOWN_POLYA    = file("${launchDir}/tests/data/cell_metadata.tsv",      checkIfExists: true)
+def SITE_CATALOG   = file("${launchDir}/tests/data/site_catalog.tsv",     checkIfExists: true)
+def TERMINAL_EXONS = file("${launchDir}/tests/data/terminal_exons.tsv",   checkIfExists: true)
+def KNOWN_POLYA    = file("${launchDir}/tests/data/known_polya.tsv",      checkIfExists: true)
 
 // ── Required header columns in pas_reference.tsv ────────────────────────────
 def REQUIRED_COLUMNS = [
@@ -43,13 +42,10 @@ def REQUIRED_COLUMNS = [
 def REQUIRED_MANIFEST_FIELDS = ['site_catalog', 'terminal_exons', 'known_polya']
 
 workflow {
-
-    ch_inputs = Channel.value([SITE_CATALOG, TERMINAL_EXONS, KNOWN_POLYA])
-
     PAS_REFERENCE_BUILD(
-        ch_inputs.map { s, t, k -> s },
-        ch_inputs.map { s, t, k -> t },
-        ch_inputs.map { s, t, k -> k }
+        Channel.value(SITE_CATALOG),
+        Channel.value(TERMINAL_EXONS),
+        Channel.value(KNOWN_POLYA)
     )
 
     // ── Assert pas_reference.tsv header ─────────────────────────────────────
@@ -58,11 +54,13 @@ workflow {
             assert f.exists()         : "pas_reference.tsv does not exist"
             assert f.size() > 0       : "pas_reference.tsv is empty"
 
-            def header = f.readLines().first().split('\t').collect { it.trim() }
+            def lines = f.readLines()
+            def header = lines.first().split('\t').collect { it.trim() }
             REQUIRED_COLUMNS.each { col ->
                 assert header.contains(col) :
                     "pas_reference.tsv missing column '${col}'. Found: ${header}"
             }
+            assert lines.size() >= 2 : "pas_reference.tsv must include at least one data row"
             log.info "[PASS] pas_reference.tsv — header OK: ${header}"
             f
         }

--- a/tests/modules/apa/test_pas_reference_build.nf
+++ b/tests/modules/apa/test_pas_reference_build.nf
@@ -1,0 +1,98 @@
+/*
+ * tests/modules/apa/test_pas_reference_build.nf
+ *
+ * Standalone module-level test for PAS_REFERENCE_BUILD.
+ *
+ * Purpose:
+ *   Validates the output contract of pas_reference_build/main.nf both while
+ *   the module runs the scaffold shell commands AND after bin/build_pas_reference.py
+ *   is wired in as the real implementation.
+ *
+ * Usage (stub — fast, no real tools needed):
+ *   nextflow run tests/modules/apa/test_pas_reference_build.nf -stub
+ *
+ * Usage (real — exercises the actual script):
+ *   nextflow run tests/modules/apa/test_pas_reference_build.nf
+ *
+ * Exit 0 = all assertions passed.
+ */
+
+nextflow.enable.dsl = 2
+
+include { PAS_REFERENCE_BUILD } from '../../../modules/local/apa/pas_reference_build/main'
+
+// ── Minimal params required by publishDir etc ─────────────────────────────────
+params.outdir           = 'tests/results/module_pas_reference_build'
+params.publish_dir_mode = 'copy'
+
+// ── Test fixtures (reuse workflow test data) ─────────────────────────────────
+// launchDir = directory from which `nextflow run` was called (repo root).
+// projectDir = directory containing this script (tests/modules/apa/).
+// NOTE: use distinct files for each input to avoid Nextflow filename collision.
+def SITE_CATALOG   = file("${launchDir}/tests/data/known_polya.tsv",       checkIfExists: true)
+def TERMINAL_EXONS = file("${launchDir}/tests/data/priming_blacklist.bed",  checkIfExists: true)
+def KNOWN_POLYA    = file("${launchDir}/tests/data/cell_metadata.tsv",      checkIfExists: true)
+
+// ── Required header columns in pas_reference.tsv ────────────────────────────
+def REQUIRED_COLUMNS = [
+    'pas_reference_id', 'site_id', 'gene_id',
+    'chrom', 'start', 'end', 'strand', 'reference_source'
+]
+
+// ── Required fields in pas_reference_build.manifest.tsv ─────────────────────
+def REQUIRED_MANIFEST_FIELDS = ['site_catalog', 'terminal_exons', 'known_polya']
+
+workflow {
+
+    ch_inputs = Channel.value([SITE_CATALOG, TERMINAL_EXONS, KNOWN_POLYA])
+
+    PAS_REFERENCE_BUILD(
+        ch_inputs.map { s, t, k -> s },
+        ch_inputs.map { s, t, k -> t },
+        ch_inputs.map { s, t, k -> k }
+    )
+
+    // ── Assert pas_reference.tsv header ─────────────────────────────────────
+    PAS_REFERENCE_BUILD.out.pas_reference
+        .map { f ->
+            assert f.exists()         : "pas_reference.tsv does not exist"
+            assert f.size() > 0       : "pas_reference.tsv is empty"
+
+            def header = f.readLines().first().split('\t').collect { it.trim() }
+            REQUIRED_COLUMNS.each { col ->
+                assert header.contains(col) :
+                    "pas_reference.tsv missing column '${col}'. Found: ${header}"
+            }
+            log.info "[PASS] pas_reference.tsv — header OK: ${header}"
+            f
+        }
+        .view { "pas_reference.tsv: ${it.name} (${it.size()} bytes)" }
+
+    // ── Assert manifest lists expected input fields ──────────────────────────
+    PAS_REFERENCE_BUILD.out.manifest
+        .map { f ->
+            assert f.exists() : "manifest TSV does not exist"
+
+            def fields = f.readLines()
+                .findAll { it.trim() && !it.startsWith('field') }
+                .collect { it.split('\t')[0].trim() }
+
+            REQUIRED_MANIFEST_FIELDS.each { field ->
+                assert fields.contains(field) :
+                    "manifest missing field '${field}'. Found: ${fields}"
+            }
+            log.info "[PASS] manifest — all required fields present: ${fields}"
+            f
+        }
+        .view { "manifest: ${it.name} (${it.size()} bytes)" }
+
+    // ── Assert log file exists and is non-empty ──────────────────────────────
+    PAS_REFERENCE_BUILD.out.log
+        .map { f ->
+            assert f.exists() : "log file does not exist"
+            assert f.size() > 0 : "log file is empty"
+            log.info "[PASS] log file present (${f.size()} bytes)"
+            f
+        }
+        .view { "log: ${it.name} (${it.size()} bytes)" }
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -112,7 +112,7 @@ run_module_test() {
     log_file="$(mktemp)"
 
     if nextflow run "$nf_file" \
-        -stub \
+        -stub-run \
         -work-dir "$work_dir" \
         -ansi-log false \
         > "$log_file" 2>&1; then

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# tests/run_tests.sh
+#
+# Local CI runner for scPolASeq.
+#
+# Runs all test scenarios (stub and optionally real) and reports per-scenario
+# pass/fail with process-count validation. Meant to be run on deepthought or
+# any machine with Nextflow in PATH.
+#
+# Usage:
+#   ./tests/run_tests.sh            # stub-run only (fast, ~1 min total)
+#   ./tests/run_tests.sh --real     # also run a real conda integration test
+#   ./tests/run_tests.sh --scenario full  # single scenario
+#
+# Exit code: 0 if all enabled scenarios pass, 1 otherwise.
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR"
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+pass() { echo -e "${GREEN}[PASS]${NC} $*"; }
+fail() { echo -e "${RED}[FAIL]${NC} $*"; }
+info() { echo -e "${YELLOW}[INFO]${NC} $*"; }
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+RUN_REAL=false
+TARGET_SCENARIO=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --real)        RUN_REAL=true; shift ;;
+        --scenario)    TARGET_SCENARIO="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ── Scenario definitions ──────────────────────────────────────────────────────
+# Format: "name|params_file|expected_stub_processes"
+# expected_stub_processes is the number of "Succeeded : N" lines in the log.
+declare -a SCENARIOS=(
+    "full|tests/config/params_full.json|22"
+    "toggles_off|tests/config/params_toggles_off.json|18"
+    "from_bam|tests/config/params_from_bam.json|22"
+    "feedback|tests/config/params_feedback.json|22"
+)
+# NOTE: Nextflow engine flags use single dash (-stub-run, -resume, -profile).
+# Double dash (--flag) is reserved for pipeline params (params.*).
+
+# ── Module-level tests ────────────────────────────────────────────────────────
+declare -a MODULE_TESTS=(
+    "pas_reference_build|tests/modules/apa/test_pas_reference_build.nf"
+)
+
+# ── Helper: run one scenario ──────────────────────────────────────────────────
+run_scenario() {
+    local name="$1"
+    local params_file="$2"
+    local expected_procs="$3"
+    local stub_flag="${4:--stub-run}"    # -stub-run or ""
+    local work_dir="$REPO_DIR/.nf_test_work/${name}_$(date +%s)"
+
+    local mode_label="stub"
+    [[ "$stub_flag" == "" ]] && mode_label="real"
+
+    info "Running scenario '${name}' (${mode_label})..."
+
+    local log_file
+    log_file="$(mktemp)"
+
+    if nextflow run . \
+        -profile test \
+        -params-file "$params_file" \
+        -work-dir "$work_dir" \
+        $stub_flag \
+        -ansi-log false \
+        > "$log_file" 2>&1; then
+
+        local actual_procs
+        actual_procs=$(grep -c "Submitted process" "$log_file" || echo "0")
+
+        if [[ "$mode_label" == "stub" && "$actual_procs" -ne "$expected_procs" ]]; then
+            fail "Scenario '${name}' (${mode_label}): expected ${expected_procs} processes, got ${actual_procs}"
+            cat "$log_file"
+            rm -f "$log_file"
+            return 1
+        fi
+
+        pass "Scenario '${name}' (${mode_label}): ${actual_procs} processes"
+        rm -f "$log_file"
+        rm -rf "$work_dir"
+        return 0
+    else
+        fail "Scenario '${name}' (${mode_label}): Nextflow exited with error"
+        grep -E "ERROR|error|WARN.*Failed" "$log_file" | head -20
+        rm -f "$log_file"
+        return 1
+    fi
+}
+
+# ── Helper: run one module test ───────────────────────────────────────────────
+run_module_test() {
+    local name="$1"
+    local nf_file="$2"
+    local work_dir="$REPO_DIR/.nf_test_work/module_${name}_$(date +%s)"
+
+    info "Running module test '${name}' (stub)..."
+
+    local log_file
+    log_file="$(mktemp)"
+
+    if nextflow run "$nf_file" \
+        -stub \
+        -work-dir "$work_dir" \
+        -ansi-log false \
+        > "$log_file" 2>&1; then
+
+        pass "Module test '${name}'"
+        rm -f "$log_file"
+        rm -rf "$work_dir"
+        return 0
+    else
+        fail "Module test '${name}'"
+        cat "$log_file"
+        rm -f "$log_file"
+        return 1
+    fi
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════════════"
+echo "  scPolASeq test suite"
+echo "  Branch : $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')"
+echo "  Commit : $(git rev-parse --short HEAD 2>/dev/null || echo 'unknown')"
+echo "══════════════════════════════════════════════════"
+echo ""
+
+FAILED=0
+
+# ── 1. Workflow stub-run scenarios ────────────────────────────────────────────
+for scenario_def in "${SCENARIOS[@]}"; do
+    IFS='|' read -r name params_file expected_procs <<< "$scenario_def"
+
+    # Filter to target scenario if --scenario was specified
+    if [[ -n "$TARGET_SCENARIO" && "$name" != "$TARGET_SCENARIO" ]]; then
+        continue
+    fi
+
+    run_scenario "$name" "$params_file" "$expected_procs" "-stub-run" || FAILED=$((FAILED + 1))
+done
+
+# ── 2. Module-level tests (stub) ─────────────────────────────────────────────
+echo ""
+info "Module-level tests"
+for module_def in "${MODULE_TESTS[@]}"; do
+    IFS='|' read -r name nf_file <<< "$module_def"
+    run_module_test "$name" "$nf_file" || FAILED=$((FAILED + 1))
+done
+
+# ── 3. Real integration test (opt-in) ────────────────────────────────────────
+if [[ "$RUN_REAL" == "true" ]]; then
+    echo ""
+    info "Real integration test (conda, full scenario)"
+    run_scenario "full_real" "tests/config/params_full.json" "0" "" || FAILED=$((FAILED + 1))
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════════════"
+if [[ "$FAILED" -eq 0 ]]; then
+    pass "All tests passed"
+else
+    fail "${FAILED} test(s) failed"
+fi
+echo "══════════════════════════════════════════════════"
+echo ""
+
+exit "$FAILED"


### PR DESCRIPTION
This pull request introduces a major refactor of the APA (Alternative Polyadenylation) analysis pipeline, consolidating APA-stage orchestration behind a new `APA_CORE` subworkflow and formalizing stable contracts for APA and PAS (Polyadenylation Site) modules. It also adds scaffold implementations for new PAS sidecar modules, updates documentation to reflect these boundaries and contracts, and introduces a new CI workflow for stub-running all scenarios. The changes are designed to make the pipeline more modular, future-proof, and easier to extend with new features or sidecar modules.

**APA Pipeline Refactor and Modularization**

- Replaces the previous 9-stage APA subworkflows in `main.nf` with a single `APA_CORE` subworkflow, isolating all APA-stage channel wiring and making it easier to add future modules without modifying the main pipeline. (`main.nf`) [[1]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L9-R10) [[2]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L58-R80)
- Adds new scaffold processes for PAS sidecar modules: `PAS_REFERENCE_BUILD`, `SIERRA_QUANT`, and `PAS_SCORING`, each with explicit Nextflow contracts and stub implementations to enable independent development and testing. (`modules/local/apa/pas_reference_build/main.nf`, `modules/local/apa/sierra_quant/main.nf`, `modules/local/apa/pas_scoring/main.nf`) [[1]](diffhunk://#diff-72bfb8f90c974587e760e904bc1cccc6e6fd538a5990348fa99ac06bbf6f80c9R1-R58) [[2]](diffhunk://#diff-a3de413658356ba430e949e0bb7bf6f0f22572c0e3dcb97e16c9eae759442d2cR1-R47) [[3]](diffhunk://#diff-82c46da2505e945ec4b3d55aff92ebc23274a7b63adf74a117aeb133e69ce9acR1-R56)

**Contract and Boundary Documentation**

- Introduces `docs/module_contracts.md`, freezing the DSL2 contracts for the APA backbone and PAS sidecars, specifying input/output channel layouts, naming conventions, and toggle behavior for each module.
- Updates `docs/design.md` with sections explaining the APA orchestration boundary, the contract strategy, and the rationale for isolating APA-stage logic behind `APA_CORE`.
- Updates `docs/outputs.md` to document new output files produced by PAS sidecar modules.

**Pipeline and Configuration Improvements**

- Removes the default `outdir` assignment from `conf/deepthought.config` to allow per-dataset profiles to set output directories without being overridden.
- Improves the `STARSOLO_ALIGN_SC` process to handle gzipped input files and only attempts BAM indexing if the BAM file exists and is non-empty. (`modules/local/alignment/starsolo_align_sc/main.nf`)

**Continuous Integration**

- Adds a new GitHub Actions workflow (`.github/workflows/ci.yml`) to stub-run all pipeline scenarios and module stubs, ensuring that changes do not break the pipeline structure or contracts.

---

**References:**  
[[1]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L9-R10) [[2]](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L58-R80) [[3]](diffhunk://#diff-72bfb8f90c974587e760e904bc1cccc6e6fd538a5990348fa99ac06bbf6f80c9R1-R58) [[4]](diffhunk://#diff-a3de413658356ba430e949e0bb7bf6f0f22572c0e3dcb97e16c9eae759442d2cR1-R47) [[5]](diffhunk://#diff-82c46da2505e945ec4b3d55aff92ebc23274a7b63adf74a117aeb133e69ce9acR1-R56) [[6]](diffhunk://#diff-b3244ad60ed8ebdb5e7573f78ddab39d5e9bfc3a34745859ae6d41becf7ed774R1-R207) [[7]](diffhunk://#diff-b0929dacd4f1fc192cd308c1a9db2e85154ea742ccec315518e659d7f6a3efc7R17-R30) [[8]](diffhunk://#diff-3b979db8fe1a091621af10f24bf1c82d8640ceecb8a784a9bcb16d2a111b0db7R35-R41) [[9]](diffhunk://#diff-72d8bd180285403a2f7e44e8dcc7ba22a941296dd9a8bfe539fdfbd59dc9bdc3L13-R16) [[10]](diffhunk://#diff-dcb59ee90844d6426fafb8c0dab2dd17082285e61a8f34389c278939929efba0R26-R53) [[11]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R81)