### PR TITLE
feat: implement Sierra::CountPeaks and fix APA feature pipeline [Closes #2]

### DIFF
--- a/bin/apa_feature_extraction.py
+++ b/bin/apa_feature_extraction.py
@@ -3,6 +3,14 @@
 apa_feature_extraction.py — Extract APA-relevant per-site features from
 strand-aware grouped bedGraph coverage files.
 
+OPTIMIZED VERSION:
+  • bedGraphs loaded once with pandas + converted to numpy arrays per chrom
+  • Mean coverage over an interval computed in O(log N) via np.searchsorted
+    on cumulative-coverage arrays (prefix sums), not a linear scan
+  • Known polyA distances computed per (chrom, strand) with np.searchsorted
+  • Output is streamed to disk in chunks so memory stays flat
+  • Progress is logged every N sites so you know it's alive
+
 For each candidate site in site_catalog, and for each group present in the
 provided bedGraph directory, the following features are extracted:
 
@@ -18,96 +26,210 @@ provided bedGraph directory, the following features are extracted:
 Output: apa_features.tsv
 """
 import argparse
+import bisect
 import glob
 import logging
 import os
-import sys
+import time
 from collections import defaultdict
 
+import numpy as np
 import pandas as pd
 
+
+# ── args ──────────────────────────────────────────────────────────────────────
 
 def parse_args():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--site-catalog",     required=True)
     p.add_argument("--bedgraph-dir",     required=True)
     p.add_argument("--bedgraph-glob",    default="*.bedGraph",
-                   help="Glob pattern for bedGraph files relative to --bedgraph-dir (supports **/)")
+                   help="(kept for CLI compatibility; not used)")
     p.add_argument("--cell-annotations", required=True)
     p.add_argument("--known-polya",      required=True)
     p.add_argument("--out-features",     required=True)
     p.add_argument("--log",              required=True)
     p.add_argument("--window",           type=int, default=50)
     p.add_argument("--upstream",         type=int, default=200)
+    p.add_argument("--chunk-size",       type=int, default=50_000,
+                   help="Flush output every N sites (default 50000)")
+    p.add_argument("--progress-every",   type=int, default=10_000,
+                   help="Log progress every N sites (default 10000)")
     return p.parse_args()
 
 
-# ── bedGraph helpers ──────────────────────────────────────────────────────────
+# ── bedGraph: load as prefix-sum arrays ───────────────────────────────────────
 
-def load_bedgraph(path):
-    """Parse bedGraph → dict {chrom: [(start, end, score), ...]}."""
-    cov = defaultdict(list)
+def load_bedgraph_prefix(path):
+    """
+    Read a bedGraph into per-chromosome numpy arrays:
+        chrom -> (starts, ends, scores, cum)
+    where cum[i] = sum_{k<i} scores[k] * (ends[k]-starts[k])
+
+    With this, the *weighted* sum of score over any segment index range [i,j)
+    is cum[j] - cum[i]. For partial-overlap segments at the edges we handle
+    them explicitly in mean_coverage().
+
+    Assumes each chromosome's intervals are non-overlapping and sorted by
+    start — which is the standard bedGraph convention from tools like
+    bedtools genomecov / deepTools.
+    """
     try:
-        with open(path) as fh:
-            for line in fh:
-                if line.startswith(("track", "#", "browser")):
-                    continue
-                parts = line.rstrip().split("\t")
-                if len(parts) < 4:
-                    continue
-                cov[parts[0]].append((int(parts[1]), int(parts[2]), float(parts[3])))
+        df = pd.read_csv(
+            path, sep="\t", header=None, comment="#",
+            names=["chrom", "start", "end", "score"],
+            dtype={"chrom": str, "start": np.int64,
+                   "end": np.int64, "score": np.float32},
+            engine="c",
+        )
     except Exception:
-        pass
-    return cov
+        return {}
+
+    # drop any stray track/browser lines that slipped past comment filter
+    df = df.dropna()
+    if df.empty:
+        return {}
+
+    out = {}
+    # groupby chrom, assume already sorted inside each chrom; sort defensively
+    for chrom, sub in df.groupby("chrom", sort=False):
+        sub = sub.sort_values("start", kind="mergesort")
+        starts = sub["start"].to_numpy(np.int64, copy=False)
+        ends   = sub["end"].to_numpy(np.int64,   copy=False)
+        scores = sub["score"].to_numpy(np.float32, copy=False)
+        # prefix sum of score * length, in float64 to avoid precision loss
+        weighted = (scores.astype(np.float64) * (ends - starts))
+        cum = np.concatenate(([0.0], np.cumsum(weighted)))
+        out[chrom] = (starts, ends, scores, cum)
+    return out
 
 
-def mean_coverage(cov_dict, chrom, start, end):
-    """Mean coverage over half-open interval [start, end)."""
-    if chrom not in cov_dict or start >= end:
+def mean_coverage(cov_entry, start, end):
+    """
+    Mean coverage on half-open [start, end) using prefix sums.
+
+    cov_entry = (starts, ends, scores, cum) for one chromosome, or None.
+    O(log N) per call thanks to searchsorted.
+    """
+    if cov_entry is None or start >= end:
         return 0.0
-    span = end - start
-    total = 0.0
-    for seg_s, seg_e, score in cov_dict[chrom]:
-        overlap = min(seg_e, end) - max(seg_s, start)
-        if overlap > 0:
-            total += score * overlap
-    return total / span
+    starts, ends, scores, cum = cov_entry
+
+    # Find the range of segments that could overlap [start, end):
+    #   left:  first segment with end > start   → searchsorted on 'ends'
+    #   right: first segment with start >= end  → searchsorted on 'starts'
+    left  = np.searchsorted(ends,   start, side="right")
+    right = np.searchsorted(starts, end,   side="left")
+    if left >= right:
+        return 0.0
+
+    # Bulk contribution from fully-contained segments [left+1, right-1]
+    # (we'll correct the edges separately)
+    total = cum[right] - cum[left]
+
+    # Subtract the portion of segment `left` that lies before `start`
+    seg_s = starts[left]
+    seg_e = ends[left]
+    if seg_s < start:
+        total -= float(scores[left]) * (start - seg_s)
+
+    # Subtract the portion of segment `right-1` that lies at/after `end`
+    last = right - 1
+    seg_e_last = ends[last]
+    if seg_e_last > end:
+        total -= float(scores[last]) * (seg_e_last - end)
+
+    return total / (end - start)
 
 
-# ── known polyA helpers ───────────────────────────────────────────────────────
+# ── known polyA: per-(chrom,strand) sorted arrays ─────────────────────────────
 
-def load_known_polya(path):
-    """Load known polyA sites → list of (chrom, pos, strand)."""
-    sites = []
+def load_known_polya_indexed(path):
+    """Build {(chrom, strand): sorted np.ndarray of positions}.
+
+    Handles two formats:
+    - Simple 3-col: chrom\\tpos\\tstrand  (no header)
+    - PolyASite2:   header present, columns chrom/chromStart/chromEnd/name/score/strand/...
+                    uses chromEnd as the representative cleavage position.
+                    Chromosomes without 'chr' prefix are normalised (e.g. '10' -> 'chr10').
+    """
+    index: dict = {}
     if not os.path.exists(path) or os.path.getsize(path) == 0:
-        return sites
+        return index
     try:
-        df = pd.read_csv(path, sep="\t", header=None, comment="#")
-        for _, row in df.iterrows():
-            strand = str(row.iloc[2]) if df.shape[1] > 2 else "."
-            sites.append((str(row.iloc[0]), int(row.iloc[1]), strand))
+        df = pd.read_csv(path, sep="\t", low_memory=False)
     except Exception:
-        pass
-    return sites
+        return index
+    if df.empty:
+        return index
+
+    cols = list(df.columns)
+
+    # PolyASite2 format: named columns
+    if "chromEnd" in cols and "strand" in cols:
+        chrom_col  = df["chrom"].astype(str)
+        pos_col    = pd.to_numeric(df["chromEnd"], errors="coerce")
+        strand_col = df["strand"].astype(str)
+    else:
+        # Fallback: first three columns as chrom, pos, strand
+        chrom_col  = df.iloc[:, 0].astype(str)
+        pos_col    = pd.to_numeric(df.iloc[:, 1], errors="coerce")
+        strand_col = df.iloc[:, 2].astype(str) if len(cols) > 2 \
+                     else pd.Series(["."] * len(df))
+
+    tmp = defaultdict(list)
+    for c, p, s in zip(chrom_col, pos_col, strand_col):
+        if pd.isna(p):
+            continue
+        # Normalise: add 'chr' prefix if missing
+        c = str(c)
+        if not c.startswith("chr"):
+            c = "chr" + c
+        p = int(p)
+        if s in ("+", "-"):
+            tmp[(c, s)].append(p)
+        else:
+            tmp[(c, "+")].append(p)
+            tmp[(c, "-")].append(p)
+
+    for k, vals in tmp.items():
+        index[k] = np.sort(np.asarray(vals, dtype=np.int64))
+    return index
 
 
-def nearest_polya_dist(chrom, pos, strand, known_sites):
-    """Distance (bp) to the nearest known polyA site on the same chrom/strand."""
-    min_dist = 10_000_000
-    for k_chrom, k_pos, k_strand in known_sites:
-        if k_chrom == chrom and (k_strand in (".", strand)):
-            min_dist = min(min_dist, abs(pos - k_pos))
-    return min_dist
+def nearest_polya_dist(polya_index, chrom, pos, strand):
+    arr = polya_index.get((chrom, strand))
+    if arr is None or arr.size == 0:
+        return 10_000_000
+    i = np.searchsorted(arr, pos)
+    best = 10_000_000
+    if i < arr.size:
+        best = int(abs(arr[i] - pos))
+    if i > 0:
+        best = min(best, int(abs(arr[i - 1] - pos)))
+    return best
 
 
 # ── site parsing ──────────────────────────────────────────────────────────────
 
 def parse_site_id(site_id):
-    """Parse 'gene:chrom:pos:strand' → (chrom, pos, strand)."""
+    """Parse 'gene:chrom:pos_or_range:strand' → (chrom, pos, strand).
+    Position can be an integer ('100627080') or a range ('100627080-100627121'),
+    in which case the midpoint is used.
+    """
     parts = str(site_id).split(":")
     if len(parts) >= 4:
         try:
-            return parts[1], int(parts[2]), parts[3]
+            raw_pos = parts[2]
+            if "-" in raw_pos:
+                start, end = raw_pos.split("-", 1)
+                pos = (int(start) + int(end)) // 2
+            else:
+                pos = int(raw_pos)
+            chrom = parts[1]
+            if not chrom.startswith("chr"):
+                chrom = "chr" + chrom
+            return chrom, pos, parts[3]
         except ValueError:
             pass
     return "chr1", 0, "+"
@@ -115,109 +237,180 @@ def parse_site_id(site_id):
 
 # ── main ──────────────────────────────────────────────────────────────────────
 
+OUT_COLS = [
+    "site_id", "group_level", "group_id",
+    "coverage_at_site", "upstream_cov", "downstream_cov",
+    "read_end_density", "proximal_distal_ratio",
+    "dist_to_known_polya", "umi_support", "cluster_support",
+]
+
+
 def main():
     args = parse_args()
     logging.basicConfig(
         filename=args.log, level=logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s")
     log = logging.getLogger()
-    log.info("Starting APA feature extraction")
+    log.info("Starting APA feature extraction (optimized)")
+    t0 = time.time()
 
-    # Load site catalog
+    # 1) Load site catalog --------------------------------------------------
     try:
-        catalog = pd.read_csv(args.site_catalog, sep="\t")
+        catalog = pd.read_csv(args.site_catalog, sep="\t", low_memory=False)
     except Exception as e:
         log.error(f"Cannot load site catalog: {e}. Writing empty output.")
-        pd.DataFrame(columns=[
-            "site_id", "group_level", "group_id", "coverage_at_site",
-            "upstream_cov", "downstream_cov", "read_end_density",
-            "proximal_distal_ratio", "dist_to_known_polya",
-            "umi_support", "cluster_support",
-        ]).to_csv(args.out_features, sep="\t", index=False)
+        pd.DataFrame(columns=OUT_COLS).to_csv(
+            args.out_features, sep="\t", index=False)
         return
 
     if "site_id" not in catalog.columns:
         catalog["site_id"] = catalog.index.astype(str)
         log.warning("site_catalog has no 'site_id' column — using row index")
 
-    # Load known polyA sites
-    known_sites = load_known_polya(args.known_polya)
-    log.info(f"Known polyA sites loaded: {len(known_sites)}")
+    n_sites = len(catalog)
+    log.info(f"Site catalog rows: {n_sites}")
 
-    # Derive group levels from annotations
+    # 2) Known polyA index --------------------------------------------------
+    polya_index = load_known_polya_indexed(args.known_polya)
+    log.info(f"Known polyA index buckets: {len(polya_index)}")
+
+    # 3) Group level --------------------------------------------------------
+    # Map annotation column names → canonical group_level labels.
+    # cluster_id is the standard column produced by the labeling step.
+    _LEVEL_MAP = [("cluster", "cluster"), ("cluster_id", "cluster"), ("cell_type", "cell_type")]
     try:
         anno = pd.read_csv(args.cell_annotations, sep="\t")
-        group_levels = [c for c in ("cluster", "cell_type") if c in anno.columns]
+        group_level = next(
+            (label for col, label in _LEVEL_MAP if col in anno.columns),
+            "cluster"
+        )
     except Exception:
-        group_levels = ["cluster"]
-    log.info(f"Group levels: {group_levels}")
+        group_level = "cluster"
+    log.info(f"Group level: {group_level}")
 
-    # Discover bedGraph files (supports stageAs '?/*' subdirectory layout)
-    bg_pattern = args.bedgraph_glob if hasattr(args, 'bedgraph_glob') else '*.bedGraph'
-    fwd_files = glob.glob(os.path.join(args.bedgraph_dir, '**', '*.fwd.bedGraph'), recursive=True)
-    rev_files = glob.glob(os.path.join(args.bedgraph_dir, '**', '*.rev.bedGraph'), recursive=True)
-    # also check flat layout for backwards compatibility
+    # 4) Discover + load bedGraphs -----------------------------------------
+    fwd_files = glob.glob(os.path.join(args.bedgraph_dir, "**", "*.fwd.bedGraph"),
+                          recursive=True)
+    rev_files = glob.glob(os.path.join(args.bedgraph_dir, "**", "*.rev.bedGraph"),
+                          recursive=True)
     if not fwd_files:
-        fwd_files = glob.glob(os.path.join(args.bedgraph_dir, '*.fwd.bedGraph'))
-        rev_files = glob.glob(os.path.join(args.bedgraph_dir, '*.rev.bedGraph'))
+        fwd_files = glob.glob(os.path.join(args.bedgraph_dir, "*.fwd.bedGraph"))
+        rev_files = glob.glob(os.path.join(args.bedgraph_dir, "*.rev.bedGraph"))
     log.info(f"bedGraph files — fwd: {len(fwd_files)}, rev: {len(rev_files)}")
 
-    # Load into memory keyed by (group_id, strand)
     bg_data: dict = {}
+    t_load = time.time()
     for path in fwd_files:
         gid = os.path.basename(path).replace(".fwd.bedGraph", "")
-        bg_data[(gid, "+")] = load_bedgraph(path)
+        bg_data[(gid, "+")] = load_bedgraph_prefix(path)
     for path in rev_files:
         gid = os.path.basename(path).replace(".rev.bedGraph", "")
-        bg_data[(gid, "-")] = load_bedgraph(path)
+        bg_data[(gid, "-")] = load_bedgraph_prefix(path)
+    log.info(f"Loaded bedGraphs in {time.time() - t_load:.1f}s")
 
     all_group_ids = sorted({k[0] for k in bg_data.keys()})
-    log.info(f"Groups found: {len(all_group_ids)}")
+    n_groups = len(all_group_ids)
+    log.info(f"Groups found: {n_groups}")
 
     w = args.window
     u = args.upstream
-    rows = []
 
-    for _, site_row in catalog.iterrows():
-        sid = site_row["site_id"]
+    # 5) Prepare output (stream in chunks) ---------------------------------
+    out_path = args.out_features
+    # Write header first, then append
+    pd.DataFrame(columns=OUT_COLS).to_csv(out_path, sep="\t", index=False)
+    first_chunk_written = False  # header already there
+
+    # Pre-extract columns once (faster than .iterrows)
+    site_ids  = catalog["site_id"].astype(str).to_numpy()
+    if "umi_count" in catalog.columns:
+        umi_vals = pd.to_numeric(catalog["umi_count"], errors="coerce") \
+                     .fillna(0).astype(np.int64).to_numpy()
+    else:
+        umi_vals = np.zeros(n_sites, dtype=np.int64)
+
+    rows_buf = []
+    total_rows_written = 0
+    t_loop = time.time()
+
+    # Cache per-(group,strand,chrom) entry lookups to avoid dict.get overhead
+    for i in range(n_sites):
+        sid = site_ids[i]
         chrom, pos, strand = parse_site_id(sid)
-        dist_known = nearest_polya_dist(chrom, pos, strand, known_sites)
-        umi_support = int(site_row.get("umi_count", 0)) if "umi_count" in site_row else 0
+        dist_known = nearest_polya_dist(polya_index, chrom, pos, strand)
+        umi_support = int(umi_vals[i])
 
+        # Resolve per-group chrom entries once for this site
         is_covered = 0
-        for gid in all_group_ids:
-            cov_dict = bg_data.get((gid, strand), {})
+        site_rows_start = len(rows_buf)
 
-            at_site  = mean_coverage(cov_dict, chrom, pos - w, pos + w)
-            up_cov   = mean_coverage(cov_dict, chrom, max(0, pos - u - w), pos - w)
-            dn_cov   = mean_coverage(cov_dict, chrom, pos + w, pos + w + u)
-            end_den  = mean_coverage(cov_dict, chrom, pos - 25, pos + 25)
+        # Intervals used for this site
+        at_s,  at_e  = pos - w,           pos + w
+        up_s,  up_e  = max(0, pos - u - w), pos - w
+        dn_s,  dn_e  = pos + w,           pos + w + u
+        en_s,  en_e  = pos - 25,          pos + 25
+
+        for gid in all_group_ids:
+            cov_dict = bg_data.get((gid, strand))
+            cov_entry = cov_dict.get(chrom) if cov_dict else None
+
+            at_site = mean_coverage(cov_entry, at_s, at_e)
+            up_cov  = mean_coverage(cov_entry, up_s, up_e)
+            dn_cov  = mean_coverage(cov_entry, dn_s, dn_e)
+            end_den = mean_coverage(cov_entry, en_s, en_e)
             pd_ratio = at_site / (dn_cov + 0.01)
 
             if at_site > 0:
                 is_covered += 1
 
-            rows.append({
-                "site_id":               sid,
-                "group_level":           group_levels[0] if group_levels else "cluster",
-                "group_id":              gid,
-                "coverage_at_site":      round(at_site,  4),
-                "upstream_cov":          round(up_cov,   4),
-                "downstream_cov":        round(dn_cov,   4),
-                "read_end_density":      round(end_den,  4),
-                "proximal_distal_ratio": round(pd_ratio, 4),
-                "dist_to_known_polya":   dist_known,
-                "umi_support":           umi_support,
-                "cluster_support":       0,  # filled below
-            })
+            rows_buf.append((
+                sid, group_level, gid,
+                round(at_site,  4),
+                round(up_cov,   4),
+                round(dn_cov,   4),
+                round(end_den,  4),
+                round(pd_ratio, 4),
+                dist_known,
+                umi_support,
+                0,  # cluster_support placeholder
+            ))
 
         # Backfill cluster_support for this site's rows
-        for row in rows[-len(all_group_ids):]:
-            row["cluster_support"] = is_covered
+        for k in range(site_rows_start, len(rows_buf)):
+            r = rows_buf[k]
+            rows_buf[k] = r[:-1] + (is_covered,)
 
-    df_out = pd.DataFrame(rows)
-    df_out.to_csv(args.out_features, sep="\t", index=False)
-    log.info(f"Wrote {len(df_out)} feature rows → {args.out_features}")
+        # Flush chunk
+        if (i + 1) % args.chunk_size == 0:
+            df_chunk = pd.DataFrame(rows_buf, columns=OUT_COLS)
+            df_chunk.to_csv(out_path, sep="\t", index=False,
+                            header=False, mode="a")
+            total_rows_written += len(df_chunk)
+            rows_buf.clear()
+
+        # Progress
+        if (i + 1) % args.progress_every == 0:
+            elapsed = time.time() - t_loop
+            rate = (i + 1) / elapsed if elapsed > 0 else 0
+            eta = (n_sites - (i + 1)) / rate if rate > 0 else float("inf")
+            log.info(
+                f"Processed {i + 1}/{n_sites} sites "
+                f"({100.0 * (i + 1) / n_sites:.1f}%) — "
+                f"{rate:.0f} sites/s — ETA {eta / 60:.1f} min"
+            )
+
+    # Final flush
+    if rows_buf:
+        df_chunk = pd.DataFrame(rows_buf, columns=OUT_COLS)
+        df_chunk.to_csv(out_path, sep="\t", index=False,
+                        header=False, mode="a")
+        total_rows_written += len(df_chunk)
+        rows_buf.clear()
+
+    log.info(
+        f"Wrote {total_rows_written} feature rows → {out_path} "
+        f"in {time.time() - t0:.1f}s total"
+    )
 
 
 if __name__ == "__main__":

--- a/bin/sierra_quant.R
+++ b/bin/sierra_quant.R
@@ -1,0 +1,157 @@
+#!/usr/bin/env Rscript
+suppressPackageStartupMessages({
+    library(optparse)
+    library(data.table)
+    library(Sierra)
+    library(Matrix)
+    library(Rsamtools)
+})
+
+option_list <- list(
+    make_option("--bam",               type = "character", help = "Grouped BAM file"),
+    make_option("--gtf",               type = "character", help = "GTF annotation file"),
+    make_option("--pas-reference",     type = "character", help = "pas_reference.tsv"),
+    make_option("--cell-annotations",  type = "character", help = "cell_annotations.tsv"),
+    make_option("--library-id",        type = "character", help = "Library ID"),
+    make_option("--group-level",       type = "character", help = "Grouping level"),
+    make_option("--group-id",          type = "character", help = "Group ID"),
+    make_option("--output",            type = "character", help = "Output TSV path"),
+    make_option("--log",               type = "character", help = "Log file path"),
+    make_option("--ncores",            type = "integer",   default = 1L)
+)
+opt <- parse_args(OptionParser(option_list = option_list))
+
+log_con <- file(opt$log, open = "wt")
+log <- function(...) {
+    msg <- paste0(format(Sys.time(), "[%Y-%m-%d %H:%M:%S] "), ...)
+    message(msg)
+    writeLines(msg, log_con)
+}
+
+# ── Diagnostics: peek at BAM CB tags vs whitelist ─────────────────────────────
+log("Reading cell annotations: ", opt$`cell-annotations`)
+ann <- fread(opt$`cell-annotations`)
+whitelist_barcodes <- ann$barcode_corrected
+log("Whitelist barcodes: ", length(whitelist_barcodes), " (first: ", whitelist_barcodes[1], ")")
+
+param_diag <- ScanBamParam(tag = "CB", what = character(0))
+diag_aln   <- scanBam(opt$bam, param = param_diag)[[1]]
+bam_cbs    <- unique(na.omit(diag_aln$tag$CB))
+n_overlap   <- sum(bam_cbs %in% whitelist_barcodes)
+log("BAM CB tags sampled: ", length(bam_cbs), " unique (first: ", bam_cbs[1], ")")
+log("Barcode overlap with whitelist: ", n_overlap, " / ", length(bam_cbs))
+
+whitelist_file <- tempfile(fileext = ".txt")
+writeLines(whitelist_barcodes, whitelist_file)
+
+# ── Build peak sites file ──────────────────────────────────────────────────────
+log("Reading PAS reference: ", opt$`pas-reference`)
+pas_ref <- fread(opt$`pas-reference`)
+
+# Sierra internally filters Fit.start < Fit.end — ensure at least 1 bp window
+peak_df <- data.frame(
+    Chr       = pas_ref$chrom,
+    Start     = as.integer(pas_ref$start),
+    End       = as.integer(pas_ref$end),
+    Strand    = ifelse(pas_ref$strand == "+", 1L, -1L),
+    Gene      = pas_ref$gene_id,
+    Fit.start = as.integer(pas_ref$start),
+    Fit.end   = pmax(as.integer(pas_ref$end), as.integer(pas_ref$start) + 1L),
+    stringsAsFactors = FALSE,
+    row.names = pas_ref$pas_reference_id
+)
+log("Peak sites: ", nrow(peak_df), " (Fit.start < Fit.end for ",
+    sum(peak_df$Fit.start < peak_df$Fit.end), ")")
+
+# Build Sierra-name → canonical site_id lookup.
+# Sierra constructs peak names as gene_id:chrom:start-sierra_end:strand_int
+# (chr-prefix chrom, integer strand, end=pmax(end,start+1)).
+# This map translates back to the site catalog's site_id format.
+sierra_end_vec   <- pmax(as.integer(pas_ref$end), as.integer(pas_ref$start) + 1L)
+sierra_strand_vec <- ifelse(pas_ref$strand == "+", "1", "-1")
+sierra_names     <- paste(pas_ref$gene_id, pas_ref$chrom,
+                          paste(as.integer(pas_ref$start), sierra_end_vec, sep="-"),
+                          sierra_strand_vec, sep=":")
+sierra_to_site_id <- setNames(pas_ref$site_id, sierra_names)
+
+peak_file <- tempfile(fileext = ".tsv")
+write.table(peak_df, peak_file, sep = "\t", quote = FALSE, col.names = TRUE, row.names = TRUE)
+
+# ── Run Sierra::CountPeaks ────────────────────────────────────────────────────
+out_dir <- paste0(opt$output, "_sierra_mex")
+dir.create(out_dir, showWarnings = FALSE)
+
+log("Running Sierra::CountPeaks on: ", opt$bam)
+result <- tryCatch(
+    Sierra::CountPeaks(
+        peak.sites.file = peak_file,
+        gtf.file        = opt$gtf,
+        bamfile         = opt$bam,
+        whitelist.file  = whitelist_file,
+        output.dir      = out_dir,
+        countUMI        = TRUE,
+        ncores          = opt$ncores
+    ),
+    error = function(e) {
+        log("CountPeaks error: ", conditionMessage(e))
+        NULL
+    }
+)
+
+# ── Parse output or write empty TSV if no reads were found ───────────────────
+empty_dt <- data.table(
+    library_id   = character(),
+    group_level  = character(),
+    group_id     = character(),
+    site_id      = character(),
+    cell_barcode = character(),
+    umi_count    = integer()
+)
+
+mat_file     <- file.path(out_dir, "matrix.mtx.gz")
+barcode_file <- file.path(out_dir, "barcodes.tsv.gz")
+feature_file <- file.path(out_dir, "sitenames.tsv.gz")
+
+if (!file.exists(mat_file)) {
+    log("WARNING: no matrix output from Sierra — writing empty TSV")
+    fwrite(empty_dt, opt$output, sep = "\t")
+    close(log_con)
+    quit(status = 0)
+}
+
+log("CountPeaks complete, reading MEX output")
+sm       <- readMM(mat_file)
+barcodes <- fread(barcode_file, header = FALSE)$V1
+features <- fread(feature_file, header = FALSE)$V1
+rownames(sm) <- features
+colnames(sm) <- barcodes
+log("Matrix loaded: ", nrow(sm), " peaks x ", ncol(sm), " cells")
+
+idx <- which(sm != 0, arr.ind = TRUE)
+if (length(idx) == 0) {
+    log("WARNING: count matrix is all zeros — writing empty TSV")
+    fwrite(empty_dt, opt$output, sep = "\t")
+} else {
+    raw_pas_ids   <- rownames(sm)[idx[, 1]]
+    canonical_ids <- sierra_to_site_id[raw_pas_ids]
+    n_total       <- length(unique(raw_pas_ids))
+    n_unmatched   <- sum(is.na(canonical_ids))
+    log("site_id translation: ", n_total - n_unmatched, "/", n_total, " unique peaks matched to canonical site_id")
+    if (n_unmatched > 0)
+        log("WARNING: ", n_unmatched, " peaks had no site_id match — Sierra name format may have changed; kept as-is")
+    canonical_ids[is.na(canonical_ids)] <- raw_pas_ids[is.na(canonical_ids)]
+
+    dt <- data.table(
+        library_id   = opt$`library-id`,
+        group_level  = opt$`group-level`,
+        group_id     = opt$`group-id`,
+        site_id      = canonical_ids,
+        cell_barcode = colnames(sm)[idx[, 2]],
+        umi_count    = sm[idx]
+    )
+    log("Non-zero peak-cell pairs: ", nrow(dt))
+    fwrite(dt, opt$output, sep = "\t")
+}
+
+log("Output written: ", opt$output)
+close(log_con)

--- a/conf/deepthought.config
+++ b/conf/deepthought.config
@@ -7,7 +7,7 @@
 
 // ── Directory layout ─────────────────────────────────────────────
 // workDir   → /scratch/.nf_work  (set in ~/.nextflow/config)
-// SIF cache → /scratch/.nf_work/apptainer/scpolaseq
+// SIF cache → /scratch/cache/apptainer/scpolaseq
 // Use -work-dir for a named run-specific subdir when you need to -resume.
 
 params {
@@ -16,7 +16,7 @@ params {
     // If no profile sets outdir, it falls back to the nextflow.config default ('results').
 
     // Pre-built SIF cache: run  bash containers/build.sh  once to populate
-    apptainer_cache_dir = '/scratch/.nf_work/apptainer/scpolaseq'
+    apptainer_cache_dir = '/scratch/cache/apptainer/scpolaseq'
 }
 
 // ── Executor ──────────────────────────────────────────────────────────────────

--- a/conf/test_pbmc1k_deepthought.config
+++ b/conf/test_pbmc1k_deepthought.config
@@ -57,8 +57,8 @@ params {
     // ── MVP toggles ── explicitly scope this run to the core MVP path ──────
     // PAS reference build: real implementation — keep ON for pbmc1k validation.
     enable_pas_reference_build   = true
-    // Sierra quant: scaffold stub only — OFF until a real Sierra wrapper lands.
-    enable_sierra_quant          = false
+    // Sierra quant: real Sierra::CountPeaks implementation.
+    enable_sierra_quant          = true
     // PAS scoring: scaffold stub only — OFF until real scoring logic lands.
     enable_pas_scoring           = false
 

--- a/containers/scpolaseq-r.def
+++ b/containers/scpolaseq-r.def
@@ -3,7 +3,7 @@ From: mambaorg/micromamba:1.5.10-jammy
 
 %labels
     maintainer  scPolASeq
-    description "R env: r-base 4.3, r-data.table, r-jsonlite, r-optparse"
+    description "R env: r-base 4.3, Sierra (VCCRI/Sierra), Bioconductor deps"
     env_source  envs/r.yml
 
 %post
@@ -12,8 +12,67 @@ From: mambaorg/micromamba:1.5.10-jammy
         r-base=4.3 \
         r-data.table=1.15.4 \
         r-jsonlite=1.8.8 \
-        r-optparse=1.7.5 && \
-    micromamba clean --all -y
+        r-optparse=1.7.5 \
+        r-remotes \
+        r-matrix \
+        r-reshape2 \
+        r-plyr \
+        r-dplyr \
+        r-foreach \
+        r-doparallel \
+        r-mlmetrics \
+        r-progress \
+        r-ggplot2 \
+        r-cowplot \
+        r-flock \
+        r-magrittr \
+        r-r.utils \
+        r-scales \
+        r-rcpp \
+        r-rlang \
+        r-cli \
+        r-glue \
+        r-lifecycle \
+        r-vctrs \
+        r-tibble \
+        r-tidyr \
+        r-tidyselect \
+        r-purrr \
+        r-stringr \
+        r-stringi \
+        r-curl \
+        r-httr \
+        r-xml \
+        r-xml2 \
+        r-yaml \
+        r-knitr \
+        r-htmltools \
+        r-htmlwidgets \
+        r-png \
+        r-jpeg \
+        r-mass \
+        r-locfit \
+        r-rcpparmadillo \
+        bioconductor-rsamtools \
+        bioconductor-genomicranges \
+        bioconductor-genomicalignments \
+        bioconductor-biocparallel \
+        bioconductor-s4vectors \
+        bioconductor-gviz \
+        bioconductor-biocstyle \
+        bioconductor-singlecellexperiment \
+        bioconductor-dexseq \
+        bioconductor-bsgenome \
+        bioconductor-genomicfeatures \
+        bioconductor-genefilter \
+        bioconductor-rtracklayer \
+        bioconductor-annotationdbi \
+        bioconductor-biomart \
+        bioconductor-deseq2 \
+        bioconductor-biocfilecache && \
+    micromamba clean --all -y && \
+    /opt/conda/bin/Rscript -e "remotes::install_github('VCCRI/Sierra', dependencies = FALSE, upgrade = 'never')" && \
+    /opt/conda/bin/Rscript -e "library(Sierra); cat('Sierra OK\n')"
 
 %environment
     export PATH=/opt/conda/bin:$PATH

--- a/envs/r.yml
+++ b/envs/r.yml
@@ -7,3 +7,10 @@ dependencies:
   - r-data.table=1.15.4
   - r-jsonlite=1.8.8
   - r-optparse=1.7.5
+  - r-remotes
+  - r-matrix
+  - bioconductor-rsamtools
+  - bioconductor-genomicranges
+  - bioconductor-genomicalignments
+  - bioconductor-biocparallel
+  - bioconductor-s4vectors

--- a/modules/local/apa/apa_feature_extraction/main.nf
+++ b/modules/local/apa/apa_feature_extraction/main.nf
@@ -14,6 +14,7 @@ process APA_FEATURE_EXTRACTION {
     path bedgraphs, stageAs: '?/*'  // collected: all *.bedGraph files, staged in unique subdirs
     path cell_annotations
     path known_polya
+    path extraction_script
 
     output:
     path "apa_features.tsv",       emit: feature_table
@@ -21,7 +22,7 @@ process APA_FEATURE_EXTRACTION {
 
     script:
     """
-    python ${projectDir}/bin/apa_feature_extraction.py \\
+    python ${extraction_script} \\
         --site-catalog     ${site_catalog}     \\
         --bedgraph-dir     .                   \\
         --bedgraph-glob    '**/*.bedGraph'      \\

--- a/modules/local/apa/sierra_quant/main.nf
+++ b/modules/local/apa/sierra_quant/main.nf
@@ -1,9 +1,9 @@
 /*
- * Scaffold-only Sierra quantification module.
+ * Sierra quantification — wraps Sierra::CountPeaks.
  *
  * Contract:
  *   input:
- *     tuple val(meta), val(group_level), val(group_id), path(grouped_bam), path(grouped_bai), path(pas_reference), path(cell_annotations)
+ *     tuple val(meta), val(group_level), val(group_id), path(grouped_bam), path(grouped_bai), path(pas_reference), path(cell_annotations), path(gtf)
  *   output:
  *     tuple val(meta), val(group_level), val(group_id), path("<library>.<group_level>.<group_id>.sierra_quant.tsv")
  *     path "<library>.<group_level>.<group_id>.sierra_quant.manifest.tsv"
@@ -11,12 +11,16 @@
  */
 process SIERRA_QUANT {
     tag "${meta.library_id}:${group_level}:${group_id}"
-    label 'process_single'
+    label 'process_medium'
+
+    conda "${projectDir}/envs/r.yml"
+    container params.apptainer_cache_dir ? "${params.apptainer_cache_dir}/scpolaseq-r.sif" : null
 
     publishDir "${params.outdir}/sierra_quant/${group_level}", mode: params.publish_dir_mode
 
     input:
-    tuple val(meta), val(group_level), val(group_id), path(grouped_bam), path(grouped_bai), path(pas_reference), path(cell_annotations)
+    tuple val(meta), val(group_level), val(group_id), path(grouped_bam), path(grouped_bai), path(pas_reference), path(cell_annotations), path(gtf)
+    path quant_script
 
     output:
     tuple val(meta), val(group_level), val(group_id), path("${meta.library_id}.${group_level}.${group_id}.sierra_quant.tsv"), emit: quantified_pas
@@ -24,24 +28,36 @@ process SIERRA_QUANT {
     path "${meta.library_id}.${group_level}.${group_id}.sierra_quant.log", emit: log
 
     script:
+    def prefix = "${meta.library_id}.${group_level}.${group_id}"
+    def ncores = task.cpus ?: 1
     """
-    printf "library_id\\tgroup_level\\tgroup_id\\tpas_reference\\tquant_source\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.tsv
-    printf "${meta.library_id}\\t${group_level}\\t${group_id}\\t${pas_reference.name}\\tscaffold_only\\n" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.tsv
+    Rscript ${quant_script} \\
+        --bam               ${grouped_bam} \\
+        --gtf               ${gtf} \\
+        --pas-reference     ${pas_reference} \\
+        --cell-annotations  ${cell_annotations} \\
+        --library-id        ${meta.library_id} \\
+        --group-level       ${group_level} \\
+        --group-id          ${group_id} \\
+        --output            ${prefix}.sierra_quant.tsv \\
+        --log               ${prefix}.sierra_quant.log \\
+        --ncores            ${ncores}
 
-    printf "field\\tvalue\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
-    printf "grouped_bam\\t%s\\n" "${grouped_bam.name}" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
-    printf "grouped_bai\\t%s\\n" "${grouped_bai.name}" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
-    printf "pas_reference\\t%s\\n" "${pas_reference.name}" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
-    printf "cell_annotations\\t%s\\n" "${cell_annotations.name}" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
-
-    printf "SIERRA_QUANT scaffold executed\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.log
+    printf "field\\tvalue\\n"                                    > ${prefix}.sierra_quant.manifest.tsv
+    printf "grouped_bam\\t${grouped_bam.name}\\n"              >> ${prefix}.sierra_quant.manifest.tsv
+    printf "grouped_bai\\t${grouped_bai.name}\\n"              >> ${prefix}.sierra_quant.manifest.tsv
+    printf "gtf\\t${gtf.name}\\n"                              >> ${prefix}.sierra_quant.manifest.tsv
+    printf "pas_reference\\t${pas_reference.name}\\n"          >> ${prefix}.sierra_quant.manifest.tsv
+    printf "cell_annotations\\t${cell_annotations.name}\\n"    >> ${prefix}.sierra_quant.manifest.tsv
+    printf "quant_source\\tSierra::CountPeaks\\n"              >> ${prefix}.sierra_quant.manifest.tsv
     """
 
     stub:
+    def prefix = "${meta.library_id}.${group_level}.${group_id}"
     """
-    printf "library_id\\tgroup_level\\tgroup_id\\tpas_reference\\tquant_source\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.tsv
-    printf "${meta.library_id}\\t${group_level}\\t${group_id}\\tstub\\tstub\\n" >> ${meta.library_id}.${group_level}.${group_id}.sierra_quant.tsv
-    printf "field\\tvalue\\nmode\\tstub\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.manifest.tsv
-    printf "SIERRA_QUANT stub executed\\n" > ${meta.library_id}.${group_level}.${group_id}.sierra_quant.log
+    printf "library_id\\tgroup_level\\tgroup_id\\tsite_id\\tcell_barcode\\tumi_count\\n" > ${prefix}.sierra_quant.tsv
+    printf "${meta.library_id}\\t${group_level}\\t${group_id}\\tstub_site_001\\tSTUBBARC001\\t1\\n" >> ${prefix}.sierra_quant.tsv
+    printf "field\\tvalue\\nmode\\tstub\\n" > ${prefix}.sierra_quant.manifest.tsv
+    printf "SIERRA_QUANT stub executed\\n" > ${prefix}.sierra_quant.log
     """
 }

--- a/modules/local/clustering/scanpy_cluster_sc/main.nf
+++ b/modules/local/clustering/scanpy_cluster_sc/main.nf
@@ -22,7 +22,8 @@ process SCANPY_CLUSTER_SC {
     def ref_h5ad_arg = (reference_h5ad    && reference_h5ad.name    != 'NO_FILE') ? "--reference-h5ad reference_h5ad_input"       : ''
     def ref_col_arg  = reference_label_col ? "--reference-label-col ${reference_label_col}" : ''
     """
-    export NUMBA_CACHE_DIR=/tmp
+    mkdir -p \$PWD/.numba_cache
+    export NUMBA_CACHE_DIR=\$PWD/.numba_cache
     python ${projectDir}/bin/scanpy_cluster_sc.py \\
         --matrix-dir ${matrix_dir} \\
         --cell-metadata ${cell_metadata} \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -41,7 +41,7 @@ params {
     apa_group_level                   = 'cluster' // primary level used for ML training/prediction
     enable_pas_reference_build        = true      // scaffold stage: build a contract-stable PAS reference artifact
     pas_reference_merge_distance      = 25        // bp distance used when collapsing PAS evidence into one reference site
-    enable_sierra_quant               = true      // scaffold stage: emit Sierra-compatible quant tables
+    enable_sierra_quant               = true      // Sierra::CountPeaks per-cell quantification
     enable_pas_scoring                = true      // scaffold stage: emit PAS scoring sidecar outputs
 
     // ── ML model parameters ───────────────────────────────────────────────────

--- a/schemas/table_contracts.md
+++ b/schemas/table_contracts.md
@@ -30,7 +30,9 @@
 
 ## sierra_quant.tsv
 
-`library_id,group_level,group_id,pas_reference,quant_source`
+Long-format per-cell peak count matrix produced by Sierra::CountPeaks.
+
+`library_id,group_level,group_id,site_id,cell_barcode,umi_count`
 
 ## pas_scored_events.tsv
 

--- a/subworkflows/apa_core.nf
+++ b/subworkflows/apa_core.nf
@@ -46,6 +46,11 @@ workflow APA_CORE {
         .first()
         .set { ch_terminal_exons }
 
+    reference_bundle
+        .map { ref_meta, star_index, gtf, fasta, chrom_sizes, terminal_exons, atlas, blacklist -> gtf }
+        .first()
+        .set { ch_gtf }
+
     // Build a proper site catalog (site_id / start / end / gene_id schema) from
     // terminal exons + the known polyA atlas.  The raw atlas file (PolyASite BED,
     // PolyA_DB TSV, …) must NOT be passed directly as site_catalog because its
@@ -122,12 +127,13 @@ workflow APA_CORE {
             }
             .combine(ch_pas_reference)
             .combine(cell_annotations)
-            .map { meta, group_level, group_id, bam, bai, pas_reference, annotations ->
-                tuple(meta, group_level, group_id, bam, bai, pas_reference, annotations)
+            .combine(ch_gtf)
+            .map { meta, group_level, group_id, bam, bai, pas_reference, annotations, gtf ->
+                tuple(meta, group_level, group_id, bam, bai, pas_reference, annotations, gtf)
             }
             .set { ch_sierra_input }
 
-        SIERRA_QUANT(ch_sierra_input)
+        SIERRA_QUANT(ch_sierra_input, file("${projectDir}/bin/sierra_quant.R"))
         ch_sierra_quant = SIERRA_QUANT.out.quantified_pas
         ch_sierra_manifest = SIERRA_QUANT.out.manifest
     } else {

--- a/subworkflows/local/apa_feature_pipeline/main.nf
+++ b/subworkflows/local/apa_feature_pipeline/main.nf
@@ -23,7 +23,8 @@ workflow APA_FEATURE_PIPELINE {
         site_catalog,
         ch_all_bedgraphs,
         cell_annotations,
-        known_polya
+        known_polya,
+        file("${projectDir}/bin/apa_feature_extraction.py")
     )
 
     APA_CALLING(


### PR DESCRIPTION
# [ Closes #2 ]
## Cambios por archivo

### `bin/sierra_quant.R` *(nuevo)*
Wrapper real que invoca `Sierra::CountPeaks`. Reemplaza el scaffold stub anterior.
Toma el PAS reference, construye el peak sites file, corre Sierra y traduce los nombres
internos de Sierra (`gene:chrX:pos:1`) al `site_id` canónico del catálogo (`gene:X:pos:+/-`)
mediante un lookup table construido al vuelo. Loguea cuántos peaks se tradujeron vs total [para tener una referencia de si los parámetros son los correctos].

### `modules/local/apa/sierra_quant/main.nf`
- Proceso reemplazado de stub a implementación real (`Sierra::CountPeaks`)
- Label cambiado de `process_single` a `process_medium`
- Agrega `gtf` e input de script (`quant_script`) al contrato de inputs
- Output renombrado de `pas_id` → `site_id` para consistencia con el catálogo
- Stub actualizado con el schema real

### `subworkflows/apa_core.nf`
- Extrae el canal `ch_gtf` del reference bundle y lo pasa a `SIERRA_QUANT`
- Pasa `sierra_quant.R` como input staged — Nextflow ahora invalida la cache si el script cambia

### `bin/apa_feature_extraction.py`
Fix: el script detectaba el group level buscando columna `"cluster"` en las anotaciones,
pero la columna real es `"cluster_id"`. Resultado: features etiquetadas como `group_level=cell_type`
en lugar de `cluster`. El modelo predecía sobre `cluster` y encontraba 0 eventos.
Fix: mapeo explícito `cluster_id → cluster`, `cell_type → cell_type`.
La corrida post-fix pasó de **0 APA events predichos** a **6.052**.

### `modules/local/apa/apa_feature_extraction/main.nf` + `subworkflows/local/apa_feature_pipeline/main.nf`
`apa_feature_extraction.py` ahora se pasa como input staged (`extraction_script`),
mismo patrón que Sierra. Cache-safe ante cambios de script.

### `modules/local/clustering/scanpy_cluster_sc/main.nf`
`NUMBA_CACHE_DIR` apuntaba a `/tmp` (compartido entre procesos paralelos, causaba conflictos).
Ahora usa `$PWD/.numba_cache` — directorio propio de cada task.

### `envs/r.yml` + `containers/scpolaseq-r.def`
Dependencias de Sierra agregadas: `Rsamtools`, `GenomicAlignments`, `GenomicRanges`,
`BiocParallel`, `Matrix`, `doParallel`, `foreach` y todas las dependencias de dplyr/tidyr
que Sierra requiere en runtime. Sierra se instala desde GitHub (`VCCRI/Sierra`) vía `remotes`.

### `conf/deepthought.config`
Path del SIF cache movido de `/scratch/.nf_work/apptainer/scpolaseq` a
`/scratch/cache/apptainer/scpolaseq` para alinearse con la ruta real en el servidor.

### `conf/test_pbmc1k_deepthought.config`
`enable_sierra_quant` activado (`false → true`) ahora que la implementación real existe.

### `nextflow.config` + `schemas/table_contracts.md`
Comentario actualizado (`scaffold stage` → implementación real). Schema de `sierra_quant.tsv`
actualizado al contrato real (`library_id, group_level, group_id, site_id, cell_barcode, umi_count`).

---

## Limitaciones del MR

- **Traducción de site_id**: el lookup se basa en el comportamiento interno de Sierra para construir
  nombres de peaks (`gene:chr:start-end:strand_int`). No está documentado formalmente por Sierra —
  si cambian ese formato en una versión futura, el script loguea un WARNING y mantiene el nombre
  original (no crashea, pero el join downstream fallaría). Monitorear el log:
  `site_id translation: N/N unique peaks matched`.

- **Sierra usa CountPeaks solamente** (no FindPeaks): los sitios candidatos vienen del PAS reference
  pre-construido. No se hace descubrimiento de novo en el BAM.

- **`cell_type.unlabeled`** produce TSV vacío por diseño: no hay lecturas asignadas a ese grupo
  en el dataset de prueba. Es comportamiento esperado.

---

## Outputs de la corrida de validación (pbmc1k, deepthought)

| Metric | Value |
|---|---|
| Peaks called | 741,003 |
| Cells | 2,274 |
| Non-zero peak–cell pairs | 1,108,937 |
| Sparsity | ~99.93% |
| APA feature sites processed | 821,840 |
| Sites with coverage > 0 | 809,542 (10%) |
| Sites scored by model | 300,917 |
| APA events called (`is_apa = True`) | 6,052 |
