### PR TITLE
10 barcode mismatch star

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 work/
 results/
+scripts/
 tests/results*/
 .nf_test_work/
 .pytest_cache/

--- a/bin/build_group_map.py
+++ b/bin/build_group_map.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 CANONICAL_COLUMNS = [
     "sample_id",
+    "library_id",
     "barcode_raw",
     "barcode_corrected",
     "cell_id",
@@ -17,6 +18,14 @@ CANONICAL_COLUMNS = [
     "batch",
     "label_source",
 ]
+
+
+def canonical_cell_id(sample_id: str, library_id: str, barcode: str) -> str:
+    parts = [sample_id]
+    if library_id:
+        parts.append(library_id)
+    parts.append(barcode)
+    return ":".join(parts)
 
 
 def load_rows(paths):
@@ -41,7 +50,7 @@ def main() -> None:
     args = parser.parse_args()
 
     rows = load_rows(args.annotation_files)
-    rows.sort(key=lambda row: ((row.get("sample_id") or ""), (row.get("barcode_corrected") or "")))
+    rows.sort(key=lambda row: ((row.get("sample_id") or ""), (row.get("library_id") or ""), (row.get("barcode_corrected") or "")))
 
     with Path(args.out_cell_annotations).open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=CANONICAL_COLUMNS, delimiter="\t")
@@ -53,6 +62,7 @@ def main() -> None:
     summary = Counter()
     for row in rows:
         sample_id = row.get("sample_id", "")
+        library_id = row.get("library_id", "")
         barcode = row.get("barcode_corrected") or row.get("barcode_raw") or ""
         condition = row.get("condition", "") or "NA"
         cluster_id = row.get("cluster_id", "")
@@ -61,7 +71,7 @@ def main() -> None:
         for level in grouping_levels:
             group_id = None
             if level == "cell":
-                group_id = row.get("cell_id") or f"{sample_id}:{barcode}"
+                group_id = row.get("cell_id") or canonical_cell_id(sample_id, library_id, barcode)
             elif level == "cluster" and cluster_id:
                 group_id = cluster_id
             elif level == "cell_type" and cell_type:
@@ -73,6 +83,7 @@ def main() -> None:
                 group_rows.append(
                     {
                         "sample_id": sample_id,
+                        "library_id": library_id,
                         "barcode_corrected": barcode,
                         "group_level": level,
                         "group_id": group_id,
@@ -81,7 +92,7 @@ def main() -> None:
                 summary[(level, group_id)] += 1
 
     with Path(args.out_group_map).open("w", newline="", encoding="utf-8") as handle:
-        fieldnames = ["sample_id", "barcode_corrected", "group_level", "group_id"]
+        fieldnames = ["sample_id", "library_id", "barcode_corrected", "group_level", "group_id"]
         writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
         writer.writeheader()
         writer.writerows(group_rows)

--- a/bin/filter_bam_by_barcodes.py
+++ b/bin/filter_bam_by_barcodes.py
@@ -24,11 +24,22 @@ def parse_args():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--bam",          required=True)
     p.add_argument("--annotations",  required=True)
+    p.add_argument("--sample-id",    default=None)
+    p.add_argument("--library-id",   default=None)
     p.add_argument("--out-bam",      required=True)
     p.add_argument("--out-stats",    required=True)
     p.add_argument("--cb-tag",       default="CB", help="BAM tag carrying cell barcode")
     p.add_argument("--ub-tag",       default="UB", help="BAM tag carrying UMI")
     return p.parse_args()
+
+
+def filter_annotations(anno, sample_id=None, library_id=None):
+    scoped = anno
+    if sample_id and "sample_id" in scoped.columns:
+        scoped = scoped[scoped["sample_id"].fillna("").astype(str).str.strip() == sample_id]
+    if library_id and "library_id" in scoped.columns:
+        scoped = scoped[scoped["library_id"].fillna("").astype(str).str.strip() == library_id]
+    return scoped
 
 
 def main():
@@ -42,6 +53,8 @@ def main():
     except Exception as e:
         log.error(f"Cannot load annotations: {e}")
         sys.exit(1)
+    anno = filter_annotations(anno, sample_id=args.sample_id, library_id=args.library_id)
+    log.info(f"Scoped annotation rows: {len(anno)}")
 
     # Resolve barcode column: accept 'barcode', 'barcode_corrected', or 'barcode_raw'
     bc_col = next(

--- a/bin/grouped_3prime_coverage.py
+++ b/bin/grouped_3prime_coverage.py
@@ -11,25 +11,33 @@ def sanitize(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]+", "_", value)
 
 
-def load_group_map(path: Path, sample_id: str):
+def row_matches_scope(row, sample_id: str, library_id: str) -> bool:
+    if row.get("sample_id") != sample_id:
+        return False
+    row_library_id = (row.get("library_id") or "").strip()
+    return not row_library_id or row_library_id == library_id
+
+
+def load_group_map(path: Path, sample_id: str, library_id: str):
     mapping = defaultdict(list)
     with path.open("r", newline="", encoding="utf-8") as handle:
         reader = csv.DictReader(handle, delimiter="\t")
         for row in reader:
-            if row.get("sample_id") != sample_id:
+            if not row_matches_scope(row, sample_id, library_id):
                 continue
-            mapping[row.get("barcode_corrected", "")].append((row.get("group_level", ""), row.get("group_id", "")))
+            barcode = row.get("barcode_corrected") or row.get("barcode_raw") or ""
+            mapping[barcode].append((row.get("group_level", ""), row.get("group_id", "")))
     return mapping
 
 
-def load_barcode_registry(path: Path, sample_id: str):
+def load_barcode_registry(path: Path, sample_id: str, library_id: str):
     rows = []
     if not path.exists() or path.stat().st_size == 0:
         return rows
     with path.open("r", newline="", encoding="utf-8") as handle:
         reader = csv.DictReader(handle, delimiter="\t")
         for row in reader:
-            if row.get("sample_id") == sample_id:
+            if row_matches_scope(row, sample_id, library_id):
                 rows.append(row)
     return rows
 
@@ -100,8 +108,8 @@ def main() -> None:
     parser.add_argument("--out-summary", required=True)
     args = parser.parse_args()
 
-    group_map = load_group_map(Path(args.group_map), args.sample_id)
-    barcode_registry = load_barcode_registry(Path(args.barcode_registry), args.sample_id)
+    group_map = load_group_map(Path(args.group_map), args.sample_id, args.library_id)
+    barcode_registry = load_barcode_registry(Path(args.barcode_registry), args.sample_id, args.library_id)
     chrom_sizes = load_chrom_sizes(Path(args.chrom_sizes))
 
     counts = count_from_bam(Path(args.bam), group_map, args.min_mapq)

--- a/bin/harmonize_cell_metadata.py
+++ b/bin/harmonize_cell_metadata.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 CANONICAL_COLUMNS = [
     "sample_id",
+    "library_id",
     "barcode_raw",
     "barcode_corrected",
     "cell_id",
@@ -17,6 +18,14 @@ CANONICAL_COLUMNS = [
     "batch",
     "label_source",
 ]
+
+
+def canonical_cell_id(sample_id: str, library_id: str, barcode: str) -> str:
+    parts = [sample_id]
+    if library_id:
+        parts.append(library_id)
+    parts.append(barcode)
+    return ":".join(parts)
 
 
 def load_table(path: Path):
@@ -29,8 +38,9 @@ def load_table(path: Path):
 
 def barcode_key(row):
     sample_id = row.get("sample_id", "")
+    library_id = row.get("library_id", "")
     barcode = row.get("barcode_corrected") or row.get("barcode_raw") or row.get("barcode") or ""
-    return sample_id, barcode
+    return sample_id, library_id, barcode
 
 
 def main() -> None:
@@ -51,9 +61,14 @@ def main() -> None:
         key = barcode_key(row)
         by_key[key] = {
             "sample_id": row.get("sample_id", ""),
+            "library_id": row.get("library_id", ""),
             "barcode_raw": row.get("barcode_raw") or row.get("barcode") or row.get("barcode_corrected", ""),
             "barcode_corrected": row.get("barcode_corrected") or row.get("barcode") or row.get("barcode_raw", ""),
-            "cell_id": row.get("cell_id") or f"{row.get('sample_id', '')}:{row.get('barcode_corrected') or row.get('barcode_raw') or row.get('barcode', '')}",
+            "cell_id": row.get("cell_id") or canonical_cell_id(
+                row.get("sample_id", ""),
+                row.get("library_id", ""),
+                row.get("barcode_corrected") or row.get("barcode_raw") or row.get("barcode", ""),
+            ),
             "cluster_id": row.get("cluster_id", ""),
             "cell_type": row.get("cell_type", ""),
             "condition": row.get("condition", ""),
@@ -67,9 +82,14 @@ def main() -> None:
             key,
             {
                 "sample_id": row.get("sample_id", ""),
+                "library_id": row.get("library_id", ""),
                 "barcode_raw": row.get("barcode_raw") or row.get("barcode") or row.get("barcode_corrected", ""),
                 "barcode_corrected": row.get("barcode_corrected") or row.get("barcode") or row.get("barcode_raw", ""),
-                "cell_id": f"{row.get('sample_id', '')}:{row.get('barcode_corrected') or row.get('barcode_raw') or row.get('barcode', '')}",
+                "cell_id": canonical_cell_id(
+                    row.get("sample_id", ""),
+                    row.get("library_id", ""),
+                    row.get("barcode_corrected") or row.get("barcode_raw") or row.get("barcode", ""),
+                ),
                 "cluster_id": "",
                 "cell_type": "",
                 "condition": row.get("condition", ""),
@@ -86,9 +106,14 @@ def main() -> None:
             key,
             {
                 "sample_id": row.get("sample_id", ""),
+                "library_id": row.get("library_id", ""),
                 "barcode_raw": row.get("barcode_raw") or row.get("barcode") or row.get("barcode_corrected", ""),
                 "barcode_corrected": row.get("barcode_corrected") or row.get("barcode") or row.get("barcode_raw", ""),
-                "cell_id": f"{row.get('sample_id', '')}:{row.get('barcode_corrected') or row.get('barcode_raw') or row.get('barcode', '')}",
+                "cell_id": canonical_cell_id(
+                    row.get("sample_id", ""),
+                    row.get("library_id", ""),
+                    row.get("barcode_corrected") or row.get("barcode_raw") or row.get("barcode", ""),
+                ),
                 "cluster_id": "",
                 "cell_type": "",
                 "condition": row.get("condition", ""),
@@ -100,7 +125,7 @@ def main() -> None:
         if not existing["label_source"]:
             existing["label_source"] = "cell_type_labels"
 
-    out_rows = sorted(by_key.values(), key=lambda row: (row["sample_id"], row["barcode_corrected"]))
+    out_rows = sorted(by_key.values(), key=lambda row: (row["sample_id"], row["library_id"], row["barcode_corrected"]))
     with Path(args.out).open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=CANONICAL_COLUMNS, delimiter="\t")
         writer.writeheader()

--- a/bin/scanpy_cluster_sc.py
+++ b/bin/scanpy_cluster_sc.py
@@ -24,7 +24,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 log = logging.getLogger()
 
 CANONICAL_COLUMNS = [
-    "sample_id", "barcode_raw", "barcode_corrected", "cell_id",
+    "sample_id", "library_id", "barcode_raw", "barcode_corrected", "cell_id",
     "cluster_id", "cell_type", "condition", "batch", "label_source",
 ]
 
@@ -37,12 +37,24 @@ def _is_sentinel(value: str) -> bool:
     return not value or value.strip() in _SENTINEL
 
 
-def load_metadata(path: Path, sample_id: str):
+def load_metadata(path: Path, sample_id: str, library_id: str):
     if not path.exists() or _is_sentinel(path.name) or path.stat().st_size == 0:
         return []
     with path.open("r", newline="", encoding="utf-8") as fh:
         reader = csv.DictReader(fh, delimiter="\t")
-        return [r for r in reader if (r.get("sample_id") or "") == sample_id]
+        rows = []
+        for row in reader:
+            if (row.get("sample_id") or "") != sample_id:
+                continue
+            row_library_id = (row.get("library_id") or "").strip()
+            if row_library_id and row_library_id != library_id:
+                continue
+            rows.append(row)
+        return rows
+
+
+def canonical_cell_id(sample_id: str, library_id: str, barcode_corrected: str) -> str:
+    return f"{sample_id}:{library_id}:{barcode_corrected}"
 
 
 def _pick_barcode_files(matrix_dir: Path):
@@ -117,6 +129,8 @@ def _load_10x_matrix(mtx_dir: Path):
 
     adata = anndata.AnnData(X=mat)
     adata.obs_names = barcodes
+    adata.obs["barcode_raw"] = barcodes
+    adata.obs["barcode_corrected"] = barcodes
     adata.var_names = var_names
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", UserWarning)
@@ -124,18 +138,101 @@ def _load_10x_matrix(mtx_dir: Path):
     return adata
 
 
-def _make_row(sample_id, bc, cluster_id, cell_type, label_source, condition="", batch=""):
+def normalize_row(row, sample_id: str, library_id: str, default_label_source: str):
+    resolved_sample_id = row.get("sample_id") or sample_id
+    resolved_library_id = row.get("library_id") or library_id
+    barcode_raw = row.get("barcode_raw") or row.get("barcode_corrected") or row.get("barcode") or ""
+    barcode_corrected = row.get("barcode_corrected") or row.get("barcode_raw") or row.get("barcode") or ""
     return {
-        "sample_id": sample_id, "barcode_raw": bc, "barcode_corrected": bc,
-        "cell_id": f"{sample_id}:{bc}", "cluster_id": cluster_id,
+        "sample_id": resolved_sample_id,
+        "library_id": resolved_library_id,
+        "barcode_raw": barcode_raw,
+        "barcode_corrected": barcode_corrected,
+        "cell_id": canonical_cell_id(resolved_sample_id, resolved_library_id, barcode_corrected),
+        "cluster_id": row.get("cluster_id", ""),
+        "cell_type": row.get("cell_type", ""),
+        "condition": row.get("condition", ""),
+        "batch": row.get("batch", ""),
+        "label_source": row.get("label_source") or default_label_source,
+    }
+
+
+def _make_row(sample_id, library_id, bc, cluster_id, cell_type, label_source, condition="", batch=""):
+    return {
+        "sample_id": sample_id,
+        "library_id": library_id,
+        "barcode_raw": bc,
+        "barcode_corrected": bc,
+        "cell_id": canonical_cell_id(sample_id, library_id, bc),
+        "cluster_id": cluster_id,
         "cell_type": cell_type, "condition": condition, "batch": batch,
         "label_source": label_source,
     }
 
 
+def annotate_adata_obs(adata, sample_id: str, library_id: str):
+    barcodes = [str(barcode) for barcode in list(adata.obs_names)]
+    cell_ids = [canonical_cell_id(sample_id, library_id, barcode) for barcode in barcodes]
+    n_obs = len(barcodes)
+    adata.obs["sample_id"] = [sample_id] * n_obs
+    adata.obs["library_id"] = [library_id] * n_obs
+    adata.obs["barcode_raw"] = barcodes
+    adata.obs["barcode_corrected"] = barcodes
+    adata.obs["cell_id"] = cell_ids
+    adata.obs_names = cell_ids
+    return adata
+
+
+def emit_embedding_plots(adata, out_plot_prefix: str) -> None:
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        log.warning(f"matplotlib not importable ({exc}); skipping embedding plots.")
+        return
+
+    base_path = Path(out_plot_prefix)
+    plot_specs = []
+
+    if "X_pca" in adata.obsm and adata.obsm["X_pca"].shape[1] >= 2:
+        plot_specs.append(("pca", adata.obsm["X_pca"][:, :2], "PCA 1", "PCA 2"))
+    if "X_umap" in adata.obsm and adata.obsm["X_umap"].shape[1] >= 2:
+        plot_specs.append(("umap", adata.obsm["X_umap"][:, :2], "UMAP 1", "UMAP 2"))
+
+    if not plot_specs:
+        log.warning("No 2D embeddings available in adata.obsm; skipping embedding plots.")
+        return
+
+    cluster_ids = [str(value) for value in adata.obs.get("cluster_id", ["unassigned"] * adata.n_obs)]
+    unique_clusters = sorted(set(cluster_ids))
+    cmap = plt.get_cmap("tab20", max(len(unique_clusters), 1))
+    color_map = {cluster_id: cmap(index) for index, cluster_id in enumerate(unique_clusters)}
+    colors = [color_map[cluster_id] for cluster_id in cluster_ids]
+
+    for embedding_name, coords, x_label, y_label in plot_specs:
+        fig, ax = plt.subplots(figsize=(7, 6))
+        ax.scatter(coords[:, 0], coords[:, 1], c=colors, s=10, linewidths=0, alpha=0.85)
+        ax.set_title(f"{base_path.name} {embedding_name.upper()} by cluster")
+        ax.set_xlabel(x_label)
+        ax.set_ylabel(y_label)
+        handles = [
+            plt.Line2D([0], [0], marker="o", color="w", label=cluster_id,
+                       markerfacecolor=color_map[cluster_id], markersize=6)
+            for cluster_id in unique_clusters
+        ]
+        if handles:
+            ax.legend(handles=handles, title="cluster_id", loc="best", fontsize=8, title_fontsize=9)
+        fig.tight_layout()
+        out_path = base_path.parent / f"{base_path.name}.{embedding_name}.png"
+        fig.savefig(out_path, dpi=150)
+        plt.close(fig)
+        log.info(f"Saved embedding plot: {out_path}")
+
+
 # ── label sources ─────────────────────────────────────────────────────────────
 
-def labels_from_celltypist(matrix_dir: Path, model_arg: str, barcodes: list, sample_id: str):
+def labels_from_celltypist(matrix_dir: Path, model_arg: str, barcodes: list, sample_id: str, library_id: str):
     """Run CellTypist. Returns (rows, mode) or (None, None) on any failure."""
     try:
         import celltypist
@@ -158,14 +255,14 @@ def labels_from_celltypist(matrix_dir: Path, model_arg: str, barcodes: list, sam
         log.warning(f"CellTypist prediction failed: {exc}; skipping.")
         return None, None
 
-    rows = [_make_row(sample_id, bc, ct_map.get(bc, "unknown"), ct_map.get(bc, "unknown"),
+    rows = [_make_row(sample_id, library_id, bc, ct_map.get(bc, "unknown"), ct_map.get(bc, "unknown"),
                       "celltypist") for bc in barcodes]
     n_types = len(set(r["cell_type"] for r in rows))
     log.info(f"CellTypist: {n_types} cell types across {len(rows)} cells")
     return rows, "celltypist"
 
 
-def labels_from_reference_h5ad(ref_path: Path, label_col: str, barcodes: list, sample_id: str):
+def labels_from_reference_h5ad(ref_path: Path, label_col: str, barcodes: list, sample_id: str, library_id: str):
     """Transfer labels from reference h5ad by barcode matching. Returns (rows, mode) or (None, None)."""
     try:
         import anndata
@@ -191,12 +288,12 @@ def labels_from_reference_h5ad(ref_path: Path, label_col: str, barcodes: list, s
         log.warning("h5ad reference: 0 barcodes matched; skipping this tier.")
         return None, None
 
-    rows = [_make_row(sample_id, bc, bc_to_label.get(bc, "unmatched"),
+    rows = [_make_row(sample_id, library_id, bc, bc_to_label.get(bc, "unmatched"),
                       bc_to_label.get(bc, "unmatched"), "reference_h5ad") for bc in barcodes]
     return rows, "reference_h5ad"
 
 
-def labels_from_leiden(matrix_dir: Path, barcodes: list, sample_id: str, resolution=0.5):
+def labels_from_leiden(matrix_dir: Path, barcodes: list, sample_id: str, library_id: str, resolution=0.5):
     """Leiden clustering via scanpy (requires leidenalg + igraph). Returns (rows, mode, adata) or (None, None, None)."""
     try:
         import leidenalg  # noqa: F401 — just to check availability
@@ -233,13 +330,13 @@ def labels_from_leiden(matrix_dir: Path, barcodes: list, sample_id: str, resolut
     rows = []
     for bc in barcodes:
         cid = f"cluster_{int(cluster_map[bc]) + 1}" if bc in cluster_map else "unassigned"
-        rows.append(_make_row(sample_id, bc, cid, "unlabeled", "leiden_clustering"))
+        rows.append(_make_row(sample_id, library_id, bc, cid, "unlabeled", "leiden_clustering"))
     adata_hvg.obs["cluster_id"] = [f"cluster_{int(cluster_map.get(bc, -1)) + 1}" if bc in cluster_map else "unassigned" for bc in adata_hvg.obs_names]
     adata_hvg.obs["label_source"] = "leiden_clustering"
     return rows, "leiden_clustering", adata_hvg
 
 
-def labels_from_kmeans(matrix_dir: Path, barcodes: list, sample_id: str, n_clusters: int = 8):
+def labels_from_kmeans(matrix_dir: Path, barcodes: list, sample_id: str, library_id: str, n_clusters: int = 8):
     """KMeans on PCA coordinates via scanpy + sklearn. Returns (rows, mode, adata) or (None, None, None)."""
     try:
         import scanpy as sc
@@ -274,7 +371,7 @@ def labels_from_kmeans(matrix_dir: Path, barcodes: list, sample_id: str, n_clust
     rows = []
     for bc in barcodes:
         cid = f"cluster_{cluster_map[bc] + 1}" if bc in cluster_map else "unassigned"
-        rows.append(_make_row(sample_id, bc, cid, "unlabeled", "kmeans_clustering"))
+        rows.append(_make_row(sample_id, library_id, bc, cid, "unlabeled", "kmeans_clustering"))
 
     # Annotate adata_hvg with cluster labels and compute UMAP for h5ad output
     adata_hvg.obs["cluster_id"] = [f"cluster_{cluster_map[bc] + 1}" if bc in cluster_map else "unassigned" for bc in adata_hvg.obs_names]
@@ -289,8 +386,8 @@ def labels_from_kmeans(matrix_dir: Path, barcodes: list, sample_id: str, n_clust
     return rows, "kmeans_clustering", adata_hvg
 
 
-def fallback_round_robin(barcodes: list, sample_id: str):
-    rows = [_make_row(sample_id, bc, f"cluster_{((i) % 3) + 1}", "unlabeled",
+def fallback_round_robin(barcodes: list, sample_id: str, library_id: str):
+    rows = [_make_row(sample_id, library_id, bc, f"cluster_{((i) % 3) + 1}", "unlabeled",
                       "fallback_internal_clustering")
             for i, bc in enumerate(barcodes)]
     return rows, "fallback_internal_clustering"
@@ -314,6 +411,7 @@ def main():
     parser.add_argument("--out-annotations",           required=True)
     parser.add_argument("--out-report",                required=True)
     parser.add_argument("--out-h5ad",                  required=True)
+    parser.add_argument("--out-plot-prefix",           default=None)
     args = parser.parse_args()
 
     sample_id = args.sample_id
@@ -324,19 +422,9 @@ def main():
     adata_out = None
 
     # ── Tier 1: External metadata TSV ─────────────────────────────────────────
-    meta_rows = load_metadata(Path(args.cell_metadata), sample_id)
+    meta_rows = load_metadata(Path(args.cell_metadata), sample_id, args.library_id)
     if meta_rows:
-        rows = [{
-            "sample_id":         r.get("sample_id", ""),
-            "barcode_raw":       r.get("barcode_raw") or r.get("barcode_corrected", ""),
-            "barcode_corrected": r.get("barcode_corrected") or r.get("barcode_raw", ""),
-            "cell_id":           r.get("cell_id") or f"{sample_id}:{r.get('barcode_corrected') or r.get('barcode_raw', '')}",
-            "cluster_id":        r.get("cluster_id", ""),
-            "cell_type":         r.get("cell_type", ""),
-            "condition":         r.get("condition", ""),
-            "batch":             r.get("batch", ""),
-            "label_source":      r.get("label_source", "external_metadata"),
-        } for r in meta_rows]
+        rows = [normalize_row(r, sample_id, args.library_id, "external_metadata") for r in meta_rows]
         clustering_mode = "external_metadata"
         log.info(f"Tier 1 (external metadata): {len(rows)} cells")
 
@@ -347,7 +435,7 @@ def main():
     # ── Tier 2: CellTypist ────────────────────────────────────────────────────
     ct_model = args.celltypist_model
     if rows is None and ct_model and not _is_sentinel(ct_model):
-        rows, clustering_mode = labels_from_celltypist(matrix_dir, ct_model, barcodes, sample_id)
+        rows, clustering_mode = labels_from_celltypist(matrix_dir, ct_model, barcodes, sample_id, args.library_id)
         if rows is not None:
             log.info(f"Tier 2 (CellTypist): {len(rows)} cells")
 
@@ -357,16 +445,16 @@ def main():
         ref_path = Path(ref_h5ad)
         if ref_path.exists() and ref_path.stat().st_size > 0:
             rows, clustering_mode = labels_from_reference_h5ad(
-                ref_path, args.reference_label_col, barcodes, sample_id)
+                ref_path, args.reference_label_col, barcodes, sample_id, args.library_id)
             if rows is not None:
                 log.info(f"Tier 3 (h5ad reference): {len(rows)} cells")
 
     # ── Tier 4: Internal Scanpy clustering ────────────────────────────────────
     if rows is None and enable_clustering and barcodes:
         # Try Leiden first, then KMeans
-        rows, clustering_mode, adata_out = labels_from_leiden(matrix_dir, barcodes, sample_id)
+        rows, clustering_mode, adata_out = labels_from_leiden(matrix_dir, barcodes, sample_id, args.library_id)
         if rows is None:
-            rows, clustering_mode, adata_out = labels_from_kmeans(matrix_dir, barcodes, sample_id)
+            rows, clustering_mode, adata_out = labels_from_kmeans(matrix_dir, barcodes, sample_id, args.library_id)
         if rows is not None:
             log.info(f"Tier 4 (internal clustering/{clustering_mode}): {len(rows)} cells")
 
@@ -375,7 +463,7 @@ def main():
         if not barcodes:
             rows, clustering_mode = [], "empty_annotations"
         else:
-            rows, clustering_mode = fallback_round_robin(barcodes, sample_id)
+            rows, clustering_mode = fallback_round_robin(barcodes, sample_id, args.library_id)
             log.info(f"Tier 5 (round-robin fallback): {len(rows)} cells")
 
     # ── Write outputs ─────────────────────────────────────────────────────────
@@ -390,10 +478,11 @@ def main():
         writer.writerow([sample_id, args.library_id, len(rows), clustering_mode])
 
     if adata_out is not None:
-        adata_out.obs["sample_id"]  = sample_id
-        adata_out.obs["library_id"] = args.library_id
+        annotate_adata_obs(adata_out, sample_id, args.library_id)
         try:
             adata_out.write_h5ad(args.out_h5ad)
+            plot_prefix = args.out_plot_prefix or str(Path(args.out_h5ad).with_suffix(""))
+            emit_embedding_plots(adata_out, plot_prefix)
             log.info(f"Saved h5ad: {args.out_h5ad} ({adata_out.n_obs} cells x {adata_out.n_vars} genes)")
         except Exception as exc:
             log.warning(f"h5ad write failed ({exc}); writing JSON stub instead.")

--- a/bin/sierra_quant.R
+++ b/bin/sierra_quant.R
@@ -28,17 +28,65 @@ log <- function(...) {
     writeLines(msg, log_con)
 }
 
+required_ann_cols <- c("library_id", "barcode_corrected")
+subset_annotations <- function(ann, library_id, group_level, group_id) {
+    missing_cols <- setdiff(required_ann_cols, colnames(ann))
+    if (length(missing_cols) > 0) {
+        stop(paste("cell_annotations.tsv missing required columns:", paste(missing_cols, collapse = ", ")))
+    }
+
+    library_mask <- ann[["library_id"]] == library_id
+    ann <- ann[library_mask, ]
+
+    if (group_level == "cluster") {
+        if (!("cluster_id" %in% colnames(ann))) {
+            stop("cell_annotations.tsv missing cluster_id needed for cluster-level Sierra quant")
+        }
+        ann <- ann[cluster_id == group_id]
+    } else if (group_level == "cell_type") {
+        if (!("cell_type" %in% colnames(ann))) {
+            stop("cell_annotations.tsv missing cell_type needed for cell_type-level Sierra quant")
+        }
+        ann <- ann[cell_type == group_id]
+    } else if (group_level == "cell") {
+        if (!("cell_id" %in% colnames(ann))) {
+            stop("cell_annotations.tsv missing cell_id needed for cell-level Sierra quant")
+        }
+        ann <- ann[cell_id == group_id]
+    }
+
+    ann
+}
+
 # ── Diagnostics: peek at BAM CB tags vs whitelist ─────────────────────────────
 log("Reading cell annotations: ", opt$`cell-annotations`)
 ann <- fread(opt$`cell-annotations`)
-whitelist_barcodes <- ann$barcode_corrected
-log("Whitelist barcodes: ", length(whitelist_barcodes), " (first: ", whitelist_barcodes[1], ")")
+ann <- subset_annotations(ann, opt$`library-id`, opt$`group-level`, opt$`group-id`)
+whitelist_barcodes <- unique(ann$barcode_corrected)
+log("Scoped annotations rows: ", nrow(ann))
+log("Whitelist barcodes after scoping: ", length(whitelist_barcodes),
+    if (length(whitelist_barcodes) > 0) paste0(" (first: ", whitelist_barcodes[1], ")") else "")
+if (length(whitelist_barcodes) == 0) {
+    log("WARNING: scoped whitelist is empty — writing empty TSV")
+    empty_dt <- data.table(
+        library_id   = character(),
+        group_level  = character(),
+        group_id     = character(),
+        site_id      = character(),
+        cell_barcode = character(),
+        umi_count    = integer()
+    )
+    fwrite(empty_dt, opt$output, sep = "\t")
+    close(log_con)
+    quit(status = 0)
+}
 
 param_diag <- ScanBamParam(tag = "CB", what = character(0))
 diag_aln   <- scanBam(opt$bam, param = param_diag)[[1]]
 bam_cbs    <- unique(na.omit(diag_aln$tag$CB))
 n_overlap   <- sum(bam_cbs %in% whitelist_barcodes)
-log("BAM CB tags sampled: ", length(bam_cbs), " unique (first: ", bam_cbs[1], ")")
+log("BAM CB tags sampled: ", length(bam_cbs), " unique",
+    if (length(bam_cbs) > 0) paste0(" (first: ", bam_cbs[1], ")") else "")
 log("Barcode overlap with whitelist: ", n_overlap, " / ", length(bam_cbs))
 
 whitelist_file <- tempfile(fileext = ".txt")

--- a/bin/write_group_bams.py
+++ b/bin/write_group_bams.py
@@ -11,6 +11,13 @@ def sanitize(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]+", "_", value)
 
 
+def grouped_bam_name(library_id: str | None, group_id: str) -> str:
+    safe_group_id = sanitize(group_id)
+    if library_id:
+        return f"{sanitize(library_id)}.{safe_group_id}.grouped.bam"
+    return f"{safe_group_id}.grouped.bam"
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     log = logging.getLogger()
@@ -20,6 +27,7 @@ def main() -> None:
                         help="Filtered BAM to split by group (optional; stub if absent/empty)")
     parser.add_argument("--group-map",     required=True)
     parser.add_argument("--sample-id",     required=True)
+    parser.add_argument("--library-id",    required=False, default=None)
     parser.add_argument("--group-level",   required=False, default=None,
                         help="Only emit groups for this group_level")
     parser.add_argument("--out-dir",       required=True)
@@ -36,6 +44,9 @@ def main() -> None:
         for row in reader:
             if args.sample_id and row.get("sample_id") != args.sample_id:
                 continue
+            row_library_id = (row.get("library_id") or "").strip()
+            if args.library_id and row_library_id and row_library_id != args.library_id:
+                continue
             level = row.get("group_level", "")
             if args.group_level and level != args.group_level:
                 continue
@@ -50,20 +61,20 @@ def main() -> None:
         if bam_path.exists() and bam_path.stat().st_size > 0:
             try:
                 import pysam
-                _split_bam(args.bam, groups, out_dir, log)
+                _split_bam(args.bam, groups, out_dir, args.library_id, log)
                 bam_valid = True
             except (ImportError, ValueError, OSError) as exc:
                 log.warning(f"BAM split unavailable ({exc}); writing placeholder BAMs")
 
     if not bam_valid:
         for _level, group_id in groups:
-            placeholder = out_dir / f"{sanitize(group_id)}.grouped.bam"
+            placeholder = out_dir / grouped_bam_name(args.library_id, group_id)
             placeholder.write_bytes(b"")
             log.info(f"Placeholder: {placeholder.name}")
 
     manifest_rows = []
     for level, group_id in groups:
-        bam_name = f"{sanitize(group_id)}.grouped.bam"
+        bam_name = grouped_bam_name(args.library_id, group_id)
         n_reads = 0
         manifest_rows.append({
             "group_level": level,
@@ -81,23 +92,30 @@ def main() -> None:
     log.info(f"Groups written: {len(manifest_rows)}")
 
 
-def _split_bam(bam_path, groups, out_dir, log):
+def _split_bam(bam_path, groups, out_dir, library_id, log):
     import pysam
 
     handles = {}
+    tag_for_group = {
+        "cluster": "CL",
+        "cell_type": "CT",
+        "cell": "CB",
+    }
     with pysam.AlignmentFile(bam_path, "rb") as bam_in:
         header = bam_in.header
-        for _level, group_id in groups:
-            out_bam = out_dir / f"{sanitize(group_id)}.grouped.bam"
-            handles[group_id] = pysam.AlignmentFile(str(out_bam), "wb", header=header)
+        for level, group_id in groups:
+            out_bam = out_dir / grouped_bam_name(library_id, group_id)
+            handles[(level, group_id)] = pysam.AlignmentFile(str(out_bam), "wb", header=header)
 
         for read in bam_in.fetch(until_eof=True):
-            try:
-                cl_tag = read.get_tag("CL")
-            except KeyError:
-                continue
-            if cl_tag in handles:
-                handles[cl_tag].write(read)
+            for level, group_id in groups:
+                tag_name = tag_for_group.get(level, "CL")
+                try:
+                    group_tag = read.get_tag(tag_name)
+                except KeyError:
+                    continue
+                if group_tag == group_id:
+                    handles[(level, group_id)].write(read)
 
     for h in handles.values():
         h.close()

--- a/conf/test_pbmc1k_deepthought.config
+++ b/conf/test_pbmc1k_deepthought.config
@@ -19,6 +19,10 @@ params {
     genome_fasta     = '/scratch/data/reference/GRCh38/genome.fa'
     gtf              = '/scratch/data/reference/GRCh38/genes.gtf'   // → gencode.v44.gtf
 
+    // Pre-built STAR index: skips genomeGenerate (saves ~10 min and 28G disk I/O).
+    // Re-generate if genome or GTF changes.
+    prebuilt_star_index = '/scratch/results/scPolASeq/pbmc1k/reference/star_index'
+
     // ── polyA atlas (see bin/download_pas_references.sh) ──────────────────────
     // Options after running the download script:
     //   10x single-cell optimised (recommended): polyasite3.0_GRCh38_10x_norm.tsv

--- a/conf/test_pbmc1k_deepthought.config
+++ b/conf/test_pbmc1k_deepthought.config
@@ -101,13 +101,42 @@ process {
     }
 
     withLabel: process_python {
-        cpus   = 8
-        memory = '32 GB'
+        cpus   = 4
+        memory = '16 GB'
     }
 
     withLabel: process_single {
         cpus   = 2
         memory = '8 GB'
+        time   = '2 h'
+    }
+
+    // Per-cluster jobs are embarrassingly parallel but single-threaded.
+    // Allocating fewer CPUs lets Nextflow schedule more concurrently:
+    //   - COVERAGE_TRACKS (pysam, 1 thread)  → 2 CPUs → 8 concurrent on 16-core host
+    //   - SIERRA_QUANT    (R Sierra, ~4 threads) → 4 CPUs → 4 concurrent
+    //   - APA_FEATURE_EXTRACTION (Python pandas, 1 thread) → 2 CPUs → 8 concurrent
+    withName: 'COVERAGE_TRACKS' {
+        cpus   = 2
+        memory = '8 GB'
+        time   = '2 h'
+    }
+
+    withName: 'SIERRA_QUANT' {
+        cpus   = 4
+        memory = '16 GB'
+        time   = '4 h'
+    }
+
+    withName: 'APA_FEATURE_EXTRACTION' {
+        cpus   = 2
+        memory = '16 GB'
+        time   = '4 h'
+    }
+
+    withName: 'SCANPY_CLUSTER_SC' {
+        cpus   = 4
+        memory = '16 GB'
         time   = '2 h'
     }
 }

--- a/docs/issue10_activity_summary.md
+++ b/docs/issue10_activity_summary.md
@@ -1,0 +1,275 @@
+# Issue #10 Activity Summary
+
+## Scope
+
+This document summarizes the work completed for GitHub issue #10 on branch `10-barcode-mismatch-star`, with emphasis on the barcode identity fix, the downstream impact on `SIERRA_QUANT`, and the later shift to sample-scoped processing from `STARsolo` onward.
+
+Reference dataset and rerun context:
+
+- Results directory: `/scratch/results/scPolASeq/pbmc1k`
+- Active work directory: `/scratch/work/scPolASeq_runs/pbmc1k_issue10`
+- Cached rerun observed in `screen`: `issue10_cached_20260502_165823`
+
+## Problem Statement
+
+The original failure mode was a barcode identity mismatch across:
+
+- STARsolo `Solo.out/Gene/filtered/barcodes.tsv`
+- `barcode_registry.tsv`
+- `cell_annotations.tsv`
+- `*.clustered.h5ad`
+- grouping / coverage / Sierra inputs
+
+This was especially visible in the `pbmc1k` sample with technical libraries `L001` and `L002`, where `L002` failed to map consistently and produced incomplete QC.
+
+## Changes Implemented
+
+### 1. Canonical barcode schema
+
+Barcode identity is now preserved explicitly instead of being reconstructed from `obs_names` or regexes.
+
+Canonical fields introduced and propagated:
+
+- `sample_id`
+- `library_id`
+- `barcode_raw`
+- `barcode_corrected`
+- `cell_id`
+
+Canonical cell identity:
+
+- `cell_id = "{sample_id}:{library_id}:{barcode_corrected}"`
+
+Design choice:
+
+- `barcode_corrected` remains the canonical STARsolo barcode
+- `obs_names` may be made globally unique, but `barcode_corrected` remains the reversible source of truth
+
+### 2. Clustering outputs hardened
+
+Updated `bin/scanpy_cluster_sc.py` and its module wrapper so that:
+
+- the H5AD stores explicit barcode columns in `adata.obs`
+- `library_id` is retained throughout clustering outputs
+- `cell_annotations.tsv` contains library-aware barcode fields
+- dimensionality reduction plots are emitted from the final H5AD
+
+Published outputs now include:
+
+- `*.clustered.h5ad`
+- `*.clustered.pca.png`
+- `*.clustered.umap.png`
+
+Confirmed in `/scratch/results/scPolASeq/pbmc1k/labels`:
+
+- `pbmc_1k_v3_L001.clustered.h5ad`
+- `pbmc_1k_v3_L001.clustered.pca.png`
+- `pbmc_1k_v3_L001.clustered.umap.png`
+- `pbmc_1k_v3_L002.clustered.h5ad`
+- `pbmc_1k_v3_L002.clustered.pca.png`
+- `pbmc_1k_v3_L002.clustered.umap.png`
+
+### 3. Grouping and BAM projection made sample-aware
+
+Updated downstream scripts so barcode-to-group joins remain stable after moving the analysis unit from lane-level `library_id` to merged `sample_id`.
+
+Key changes:
+
+- `group_map.tsv` still carries `library_id` for backward compatibility
+- BAM filtering can still respect library scoping, but sample-merged STARsolo now emits `library_id == sample_id`
+- grouped BAM generation uses the correct BAM tag by grouping mode:
+  - `cluster -> CL`
+  - `cell_type -> CT`
+  - `cell -> CB`
+- grouped BAM filenames are prefixed with the active analysis identifier, which now mirrors `sample_id`
+
+### 4. Sierra whitelist scoping fixed
+
+`bin/sierra_quant.R` now scopes `cell_annotations.tsv` before building the whitelist.
+
+Current scoping logic:
+
+- filter annotations by `library_id`
+- then restrict by:
+  - `cluster_id == group_id` for `group_level=cluster`
+  - `cell_type == group_id` for `group_level=cell_type`
+  - `cell_id == group_id` for `group_level=cell`
+
+This removed the earlier bug where Sierra counted a grouped BAM with a full-library whitelist.
+
+### 5. `STARsolo` now merges rows by `sample_id`
+
+The pipeline now groups validated samplesheet rows by `sample_id` before entering `STARSOLO_ALIGN_SC`.
+
+For `pbmc1k`, the original rows:
+
+- `pbmc_1k_v3_L001`
+- `pbmc_1k_v3_L002`
+
+are now merged into one STARsolo execution keyed by:
+
+- `sample_id = pbmc_1k_v3`
+
+Downstream consequences:
+
+- one STARsolo matrix per sample
+- one alignment BAM per sample
+- one H5AD per sample
+- one unified barcode namespace per sample
+- no downstream need to reconcile cells across lane-specific STARsolo outputs
+
+## Container Validation
+
+The Sierra module uses the Apptainer image configured by the pipeline:
+
+- `container "${params.apptainer_cache_dir}/scpolaseq-r.sif"`
+
+For the deepthought/apptainer profile used here, that resolves to:
+
+- `/scratch/cache/apptainer/scpolaseq/scpolaseq-r.sif`
+
+Validation completed inside that container:
+
+- `Rscript` parse check for `bin/sierra_quant.R`: passed
+- manual rerun of one Sierra workdir using the patched script: passed
+
+Observed successful scoped run:
+
+- Workdir: `/scratch/work/scPolASeq_runs/pbmc1k_issue10/2f/a88623ba24f3ed52fcac4ab74accb7`
+- Log highlights:
+  - `Scoped annotations rows: 12`
+  - `Whitelist barcodes after scoping: 12`
+  - `BAM CB tags sampled: 12 unique`
+  - `Matrix loaded: 741003 peaks x 12 cells`
+  - `Output written: recheck.cluster_8.sierra_quant.tsv`
+
+## Current Rerun Status as of 2026-05-02
+
+### What is corrected
+
+- H5ADs are present and published
+- dimensionality plots are present and published
+- barcode identity is explicit in annotations and H5AD
+- Sierra no longer defaults to a full-library whitelist when the inputs are scoped correctly
+
+### What is still failing
+
+The cached rerun on 2026-05-02 exposed a new mismatch in the APA chain.
+
+Observed in recent Sierra logs under `/scratch/work/scPolASeq_runs/pbmc1k_issue10`:
+
+- `Scoped annotations rows: 0`
+- `Whitelist barcodes after scoping: 0`
+- `WARNING: scoped whitelist is empty — writing empty TSV`
+
+Examples:
+
+- `.../72/de1b1aff255c209488be932929884b/pbmc_1k_v3_L002.cluster.pbmc_1k_v3_L002.cluster_1.sierra_quant.log`
+- `.../ff/a1ce358d7945f5b9c47e850add047d/pbmc_1k_v3_L002.cluster.pbmc_1k_v3_L002.cluster_8.sierra_quant.log`
+- `.../0b/a2bd3e4635cabbb252a358d0c8878f/pbmc_1k_v3_L001.cell_type.pbmc_1k_v3_L001.unlabeled.sierra_quant.log`
+
+Published outputs show the same pattern:
+
+- legacy files like `pbmc_1k_v3_L002.cluster.cluster_8.sierra_quant.tsv` remain populated
+- newly prefixed files like `pbmc_1k_v3_L002.cluster.pbmc_1k_v3_L002.cluster_8.sierra_quant.tsv` are header-only
+
+## Root Cause of the Remaining Sierra Issue
+
+The problem is in `subworkflows/apa_core.nf`.
+
+Current logic derives `group_id` from the grouped BAM filename:
+
+```groovy
+def group_id = bam.baseName.replaceAll(/\.grouped(\.bam)?$/, '')
+```
+
+After the grouped BAM naming change, filenames became analysis-prefixed, for example:
+
+- `pbmc_1k_v3.cluster_8.grouped.bam`
+
+That means `group_id` becomes:
+
+- `pbmc_1k_v3.cluster_8`
+
+But the annotation table still stores:
+
+- `cluster_id = cluster_8`
+
+So the Sierra scoping filter would compare:
+
+- `cluster_id == pbmc_1k_v3.cluster_8`
+
+instead of:
+
+- `cluster_id == cluster_8`
+
+That bug is now patched by stripping the active analysis prefix before calling Sierra.
+
+Result before the patch:
+
+- the whitelist becomes empty
+- Sierra emits an empty TSV by design
+
+## Recommendations
+
+### Immediate fix
+
+The active patch now strips the `{analysis_id}.` prefix before calling `SIERRA_QUANT`.
+
+Preferred long-term option:
+
+1. Pass `group_id` directly from the grouping manifest generated by `GROUPED_BAM_GENERATION`.
+
+### Stability improvements
+
+- Treat manifest metadata as authoritative and filenames as presentation only.
+- Add a preflight assertion before Sierra:
+  - `group_id` must match at least one row in scoped `cell_annotations.tsv`
+- Add a regression test covering:
+  - two libraries sharing the same barcode namespace
+  - grouped BAM filenames prefixed by `library_id`
+  - Sierra scoping for both `cluster` and `cell_type`
+- Consider publishing grouped BAMs in per-sample subdirectories even when filenames are already prefixed.
+
+### Observability improvements
+
+- Keep `Scoped annotations rows` and `Whitelist barcodes after scoping` in Sierra logs
+- Add a post-run QC summary that flags header-only Sierra outputs
+- Add a report table mapping:
+  - `library_id`
+  - `group_level`
+  - `group_id`
+  - `n_cells_in_annotations`
+  - `n_cb_tags_in_bam`
+  - `n_rows_in_sierra_output`
+
+## Files Touched During the Issue #10 Fix
+
+Core logic:
+
+- `bin/scanpy_cluster_sc.py`
+- `bin/build_group_map.py`
+- `bin/grouped_3prime_coverage.py`
+- `bin/filter_bam_by_barcodes.py`
+- `bin/write_group_bams.py`
+- `bin/harmonize_cell_metadata.py`
+- `bin/sierra_quant.R`
+
+Workflow and module wiring:
+
+- `modules/local/clustering/scanpy_cluster_sc/main.nf`
+- `modules/local/bam/bam_barcode_filter/main.nf`
+- `modules/local/grouping/grouped_bam_generation/main.nf`
+- `subworkflows/apa_core.nf`
+
+Support material:
+
+- `docs/module_contracts.md`
+- `docs/outputs.md`
+- `tests/test_issue10_barcode_identity.py`
+
+## Bottom Line
+
+The original barcode identity problem from STARsolo through clustering has been substantially fixed, and the workflow is now being shifted to sample-scoped STARsolo processing so the biological unit stays consistent from alignment onward.
+
+The remaining Sierra failure observed in the 2026-05-02 cached rerun was localized to `group_id` derivation from prefixed grouped BAM filenames inside `APA_CORE`. That normalization is now patched, and the clean verification run should confirm the end-to-end behavior under the new sample-level strategy.

--- a/docs/module_contracts.md
+++ b/docs/module_contracts.md
@@ -66,7 +66,9 @@ path("*filter*.tsv")
 
 Notes:
 `meta.library_id` remains the library-scoped identity anchor. Filtering must not
-rewrite sample identities.
+rewrite sample identities. Unified `cell_annotations.tsv` inputs must carry
+explicit `sample_id`, `library_id`, `barcode_raw`, `barcode_corrected`, and a
+reversible `cell_id = <sample_id>:<library_id>:<barcode_corrected>`.
 
 ### `GROUPED_RECONSTRUCTION`
 
@@ -83,7 +85,9 @@ path("*.grouping_manifest.tsv")
 
 Notes:
 the output channel is library-scoped. One emission may contain multiple grouped
-BAM paths for the same `(meta, group_level)` pair.
+BAM paths for the same `(meta, group_level)` pair. When `group_map.tsv`
+contains `library_id`, consumers must scope barcode/group lookups to the active
+library before matching on `barcode_corrected`.
 
 ### `COVERAGE_GENERATION`
 
@@ -118,6 +122,14 @@ path("apa_features.tsv")
 path("apa_events.tsv")
 path("pdui_usage_matrix.tsv")
 ```
+
+Unified label tables:
+
+- `cell_annotations.tsv` canonical columns:
+  `sample_id`, `library_id`, `barcode_raw`, `barcode_corrected`, `cell_id`,
+  `cluster_id`, `cell_type`, `condition`, `batch`, `label_source`
+- `group_map.tsv` canonical columns:
+  `sample_id`, `library_id`, `barcode_corrected`, `group_level`, `group_id`
 
 ### `MODEL_PIPELINE`
 

--- a/docs/module_contracts.md
+++ b/docs/module_contracts.md
@@ -65,8 +65,9 @@ path("*filter*.tsv")
 ```
 
 Notes:
-`meta.library_id` remains the library-scoped identity anchor. Filtering must not
-rewrite sample identities. Unified `cell_annotations.tsv` inputs must carry
+the analysis unit is sample-scoped from `STARsolo` onward. In sample-merged
+runs, `meta.library_id` mirrors `meta.sample_id` for backward compatibility
+with stable module interfaces. Unified `cell_annotations.tsv` inputs must carry
 explicit `sample_id`, `library_id`, `barcode_raw`, `barcode_corrected`, and a
 reversible `cell_id = <sample_id>:<library_id>:<barcode_corrected>`.
 
@@ -84,10 +85,10 @@ path("*.grouping_manifest.tsv")
 ```
 
 Notes:
-the output channel is library-scoped. One emission may contain multiple grouped
-BAM paths for the same `(meta, group_level)` pair. When `group_map.tsv`
-contains `library_id`, consumers must scope barcode/group lookups to the active
-library before matching on `barcode_corrected`.
+the output channel is sample-scoped. One emission may contain multiple grouped
+BAM paths for the same `(meta, group_level)` pair. In sample-merged runs,
+`group_map.tsv` still carries `library_id`, but that value mirrors the active
+sample analysis unit unless a legacy import path overrides it.
 
 ### `COVERAGE_GENERATION`
 
@@ -185,7 +186,7 @@ path("*.sierra_quant.log")
 ```
 
 Naming rule:
-`<library_id>.<group_level>.<group_id>.sierra_quant.tsv`
+`<sample_id>.<group_level>.<group_id>.sierra_quant.tsv`
 
 ### `PAS_SCORING`
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -7,12 +7,14 @@
 
 ## Alignment
 
-- `alignment/<library_id>.Aligned.sortedByCoord.out.bam`
-- `alignment/<library_id>.barcode_registry.tsv`
-- `alignment/<library_id>.alignment_manifest.tsv`
+- `alignment/<sample_id>.Aligned.sortedByCoord.out.bam`
+- `alignment/<sample_id>.barcode_registry.tsv`
+- `alignment/<sample_id>.alignment_manifest.tsv`
 
 `barcode_registry.tsv` preserves STARsolo barcodes verbatim in
 `barcode_raw` and `barcode_corrected`, including 10x suffixes such as `-1`.
+When multiple FASTQ rows share the same `sample_id`, they are merged before
+`STARsolo`; downstream alignment outputs are therefore sample-scoped.
 
 ## Labels and grouping
 
@@ -27,17 +29,17 @@
 `group_map.tsv` canonical columns:
 `sample_id`, `library_id`, `barcode_corrected`, `group_level`, `group_id`
 
-`<library_id>.clustered.h5ad` stores explicit `obs` columns
+`<sample_id>.clustered.h5ad` stores explicit `obs` columns
 `sample_id`, `library_id`, `barcode_raw`, `barcode_corrected`, and `cell_id`.
 If the AnnData index is rewritten for uniqueness, `barcode_corrected` remains
 the canonical STARsolo barcode and `cell_id` remains reversible.
 
 ## Coverage
 
-- `coverage/<library_id>.grouped_3prime_counts.tsv`
-- `coverage/<library_id>.coverage_summary.tsv`
-- `coverage/<library_id>/tracks/*.bedGraph`
-- `coverage/<library_id>/tracks/*.bigWig`
+- `coverage/<sample_id>.grouped_3prime_counts.tsv`
+- `coverage/<sample_id>.coverage_summary.tsv`
+- `coverage/<sample_id>/tracks/*.bedGraph`
+- `coverage/<sample_id>/tracks/*.bigWig`
 
 ## APA
 
@@ -51,7 +53,7 @@ the canonical STARsolo barcode and `cell_id` remains reversible.
 
 - `pas_reference/pas_reference.tsv`
 - `pas_reference/pas_reference_build.manifest.tsv`
-- `sierra_quant/<group_level>/<library_id>.<group_level>.<group_id>.sierra_quant.tsv`
+- `sierra_quant/<group_level>/<sample_id>.<group_level>.<group_id>.sierra_quant.tsv`
 - `pas_scoring/pas_scored_events.tsv`
 
 ## Report

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -11,11 +11,26 @@
 - `alignment/<library_id>.barcode_registry.tsv`
 - `alignment/<library_id>.alignment_manifest.tsv`
 
+`barcode_registry.tsv` preserves STARsolo barcodes verbatim in
+`barcode_raw` and `barcode_corrected`, including 10x suffixes such as `-1`.
+
 ## Labels and grouping
 
 - `labels/cell_annotations.tsv`
 - `labels/group_map.tsv`
 - `labels/group_summary.tsv`
+
+`cell_annotations.tsv` canonical columns:
+`sample_id`, `library_id`, `barcode_raw`, `barcode_corrected`, `cell_id`,
+`cluster_id`, `cell_type`, `condition`, `batch`, `label_source`
+
+`group_map.tsv` canonical columns:
+`sample_id`, `library_id`, `barcode_corrected`, `group_level`, `group_id`
+
+`<library_id>.clustered.h5ad` stores explicit `obs` columns
+`sample_id`, `library_id`, `barcode_raw`, `barcode_corrected`, and `cell_id`.
+If the AnnData index is rewritten for uniqueness, `barcode_corrected` remains
+the canonical STARsolo barcode and `cell_id` remains reversible.
 
 ## Coverage
 

--- a/docs/workflow_to_sierra_quant.md
+++ b/docs/workflow_to_sierra_quant.md
@@ -1,0 +1,496 @@
+# Workflow to Sierra Quant
+
+## Purpose
+
+This document explains the execution path from sample sheet ingestion to `SIERRA_QUANT` for the `pbmc1k` validation run, including the relevant processes, parameters, intermediate contracts, and improvement opportunities.
+
+Run context described here matches the deepthought PBMC config and the current sample-merged execution strategy:
+
+- Config: `conf/test_pbmc1k_deepthought.config`
+- Results: `/scratch/results/scPolASeq/pbmc1k`
+- Work directory: `/scratch/work/scPolASeq_runs/pbmc1k_issue10`
+
+## Top-Level Workflow
+
+The entrypoint is `workflow SCPOLASEQ` in `main.nf`.
+
+High-level stages:
+
+1. `INPUT_HARMONIZATION`
+2. `REFERENCE_PREPARE`
+3. `ALIGN_OR_IMPORT_SC`
+4. `CELL_LABELING_SC`
+5. `APA_CORE`
+6. `REPORTING_SC`
+
+The path into Sierra is:
+
+`main.nf -> CELL_LABELING_SC -> APA_CORE -> BARCODE_FILTERING -> GROUPED_RECONSTRUCTION -> SIERRA_QUANT`
+
+## Run Parameters Used for PBMC1K
+
+From `conf/test_pbmc1k_deepthought.config`:
+
+### Inputs
+
+- `input = /scratch/data/pbmc1k/samplesheet.csv`
+- `genome_fasta = /scratch/data/reference/GRCh38/genome.fa`
+- `gtf = /scratch/data/reference/GRCh38/genes.gtf`
+- `prebuilt_star_index = /scratch/results/scPolASeq/pbmc1k/reference/star_index`
+- `known_polya = /scratch/data/polya_atlas/polyasite2_GRCh38.tsv`
+
+### Output and execution mode
+
+- `outdir = /scratch/results/scPolASeq/pbmc1k`
+- `run_mode = full`
+- `aligner = starsolo`
+- `protocol_mode = 10x_3p`
+
+### Clustering and grouping
+
+- `enable_internal_clustering = true`
+- `grouping_levels = cluster,cell_type`
+- `apa_grouping_levels = cluster,cell_type`
+- `apa_group_level = cluster`
+
+### Coverage and APA
+
+- `emit_group_bams = false`
+- `emit_bigwigs = true`
+- `apa_min_coverage = 5`
+- `apa_min_pdui_delta = 0.2`
+- `apa_model_type = random_forest`
+- `enable_single_cell_apa_projection = false`
+- `enable_pas_reference_build = true`
+- `enable_sierra_quant = true`
+- `enable_pas_scoring = false`
+
+### Resources
+
+- `max_cpus = 16`
+- `max_memory = 120 GB`
+- `max_time = 24 h`
+
+## Stage-by-Stage Flow
+
+## 1. Input Harmonization
+
+Process family:
+
+- `INPUT_HARMONIZATION`
+
+Role:
+
+- normalizes the sample sheet and optional external metadata inputs
+- produces the sample descriptors consumed by alignment and labeling stages
+
+Important contract:
+
+- each sample/library travels downstream as `meta`
+- `meta` is expected to carry at least `sample_id` and `library_id`
+
+## 2. Reference Preparation
+
+Process family:
+
+- `REFERENCE_PREPARE`
+
+Role:
+
+- validates/stages genome FASTA and GTF
+- exposes the reference bundle
+- passes the known polyA atlas into later APA stages
+
+Reference bundle consumed later by `APA_CORE` contains:
+
+- STAR index
+- GTF
+- FASTA
+- chromosome sizes
+- terminal exons
+- atlas
+- blacklist
+
+## 3. Alignment or Import
+
+Process family:
+
+- `ALIGN_OR_IMPORT_SC`
+- for this run, the active aligner path is STARsolo
+
+Relevant runtime parameters:
+
+- `run_mode = full`
+- `aligner = starsolo`
+- `protocol_mode = 10x_3p`
+
+Role:
+
+- merge validated samplesheet rows by `sample_id` before STARsolo
+- generate one alignment output set and one 10x-like expression matrix per sample
+- preserve CB/UB tags in BAM
+- emit:
+  - `bam_bundle`
+  - `matrix_bundle`
+
+For the PBMC1K example, the input rows:
+
+- `pbmc_1k_v3_L001`
+- `pbmc_1k_v3_L002`
+
+are collapsed into a single STARsolo job for:
+
+- `pbmc_1k_v3`
+
+Key outputs used downstream:
+
+- `bam_bundle`: sample BAM + BAI
+- `matrix_bundle`: sample STARsolo matrix directory with `barcodes.tsv`
+
+## 4. Cell Labeling and Clustering
+
+Subworkflow:
+
+- `CELL_LABELING_SC`
+
+Included modules:
+
+- `SCANPY_CLUSTER_SC`
+- `BUILD_GROUP_MAP`
+- `WRITE_MANIFESTS`
+
+### 4.1 `SCANPY_CLUSTER_SC`
+
+Input tuple:
+
+- `meta`
+- `matrix_dir`
+- `cell_metadata`
+- `enable_internal_clustering`
+- `celltypist_model`
+- `reference_h5ad`
+- `reference_label_col`
+
+CLI arguments passed by the module:
+
+- `--matrix-dir`
+- `--cell-metadata`
+- `--sample-id`
+- `--library-id`
+- `--enable-internal-clustering`
+- optional:
+  - `--celltypist-model`
+  - `--reference-h5ad`
+  - `--reference-label-col`
+- outputs:
+  - `--out-annotations`
+  - `--out-report`
+  - `--out-h5ad`
+  - `--out-plot-prefix`
+
+Role:
+
+- load STARsolo matrix
+- cluster cells internally
+- attach canonical barcode fields
+- emit per-library cell annotations
+- emit clustered H5AD
+- emit PCA and UMAP plots for inspection
+
+Published outputs in `results/.../labels`:
+
+- `<library>.cell_annotations.tsv`
+- `<library>.cluster_report.tsv`
+- `<library>.clustered.h5ad`
+- `<library>.clustered.pca.png`
+- `<library>.clustered.umap.png`
+
+Canonical identity fields now expected in the H5AD and annotations:
+
+- `sample_id`
+- `library_id`
+- `barcode_raw`
+- `barcode_corrected`
+- `cell_id`
+
+### 4.2 `BUILD_GROUP_MAP`
+
+Role:
+
+- merges per-library annotation tables
+- writes:
+  - unified `cell_annotations.tsv`
+  - unified `group_map.tsv`
+  - group summary outputs
+
+Important contract:
+
+- `group_map.tsv` must retain `library_id`
+- joins should be library-aware whenever the same 10x barcode appears in multiple libraries
+
+## 5. APA Core Entry
+
+Subworkflow:
+
+- `APA_CORE`
+
+Inputs into `APA_CORE` from `main.nf`:
+
+- `reference_bundle`
+- `bam_bundle`
+- unified `cell_annotations.tsv`
+- unified `group_map.tsv`
+- `known_polya`
+- `apa_grouping_levels`
+- `apa_min_coverage`
+- `apa_min_pdui_delta`
+- `apa_model_type`
+- `apa_model_group_level`
+
+Feature toggles resolved at runtime:
+
+- `enable_single_cell_apa_projection`
+- `enable_pas_reference_build`
+- `enable_sierra_quant`
+- `enable_pas_scoring`
+
+## 6. Barcode Filtering
+
+Subworkflow:
+
+- `BARCODE_FILTERING`
+
+Included module:
+
+- `BAM_BARCODE_FILTER`
+
+Role:
+
+- takes library BAMs from `bam_bundle`
+- filters them against unified `cell_annotations.tsv`
+- projects cell metadata back into BAM records through tags used later by grouping
+
+Expected behavior after the issue #10 fix:
+
+- annotation lookup is constrained by `sample_id` and `library_id`
+- barcode mapping is driven by canonical barcode fields instead of reconstructed names
+
+In sample-merged runs:
+
+- `library_id` mirrors `sample_id`
+- the filtered BAM already represents the whole sample
+
+Outputs:
+
+- filtered BAM + BAI
+- filter stats
+
+## 7. Grouped Reconstruction
+
+Subworkflow:
+
+- `GROUPED_RECONSTRUCTION`
+
+Included module:
+
+- `GROUPED_BAM_GENERATION`
+
+Inputs:
+
+- filtered BAM
+- unified `group_map.tsv`
+- grouping levels from `apa_grouping_levels`
+
+For the PBMC run, active grouping levels are:
+
+- `cluster`
+- `cell_type`
+
+### 7.1 `GROUPED_BAM_GENERATION`
+
+CLI arguments passed:
+
+- `--bam`
+- `--group-map`
+- `--sample-id`
+- `--library-id`
+- `--group-level`
+- `--out-dir`
+- `--out-manifest`
+
+Role:
+
+- split one filtered BAM into one BAM per `(library_id, group_level, group_id)`
+- index every grouped BAM
+- emit a grouping manifest
+
+Current group tag behavior in `write_group_bams.py`:
+
+- `cluster` uses BAM tag `CL`
+- `cell_type` uses BAM tag `CT`
+- `cell` uses BAM tag `CB`
+
+Current naming behavior:
+
+- grouped BAMs are prefixed with the active analysis identifier
+- example: `pbmc_1k_v3.cluster_8.grouped.bam`
+
+Why this matters:
+
+- the filename prefix still prevents collisions in published outputs
+- downstream code must not assume that the BAM basename equals the semantic `group_id`
+
+## 8. Coverage and Feature Extraction
+
+Parallel branches inside `APA_CORE`:
+
+- `COVERAGE_GENERATION`
+- `APA_FEATURE_PIPELINE`
+- `MODEL_PIPELINE`
+- `PAS_REFERENCE_BUILD`
+
+These stages are not the direct cause of the current Sierra mismatch, but they depend on the same grouped BAM and annotation contracts.
+
+Relevant outputs feeding reporting and APA interpretation:
+
+- bedGraphs and bigWigs
+- feature tables
+- APA event tables
+- PDUI matrix
+- optional PAS reference
+
+## 9. Sierra Quantification
+
+Module:
+
+- `SIERRA_QUANT`
+
+Container:
+
+- `${params.apptainer_cache_dir}/scpolaseq-r.sif`
+
+For the current profile:
+
+- `/scratch/cache/apptainer/scpolaseq/scpolaseq-r.sif`
+
+Input tuple:
+
+- `meta`
+- `group_level`
+- `group_id`
+- `grouped_bam`
+- `grouped_bai`
+- `pas_reference`
+- `cell_annotations`
+- `gtf`
+
+CLI arguments passed to `bin/sierra_quant.R`:
+
+- `--bam`
+- `--gtf`
+- `--pas-reference`
+- `--cell-annotations`
+- `--library-id`
+- `--group-level`
+- `--group-id`
+- `--output`
+- `--log`
+- `--ncores`
+
+Role:
+
+- build a group-scoped whitelist from annotations
+- call `Sierra::CountPeaks`
+- write:
+  - `<library>.<group_level>.<group_id>.sierra_quant.tsv`
+  - manifest
+  - log
+
+## Current Sierra Behavior
+
+### Corrected behavior
+
+The Sierra script now scopes annotations before counting.
+
+Expected log signals for a healthy run:
+
+- `Scoped annotations rows: N`
+- `Whitelist barcodes after scoping: N`
+- `Matrix loaded: ... x N cells`
+
+Validated real example:
+
+- workdir `/scratch/work/scPolASeq_runs/pbmc1k_issue10/2f/a88623ba24f3ed52fcac4ab74accb7`
+- `Scoped annotations rows: 12`
+- `Whitelist barcodes after scoping: 12`
+- `Matrix loaded: 741003 peaks x 12 cells`
+
+### Historical failure mode
+
+`APA_CORE` currently derives `group_id` from the grouped BAM filename:
+
+```groovy
+def group_id = bam.baseName.replaceAll(/\.grouped(\.bam)?$/, '')
+```
+
+Because grouped BAMs are prefixed, this produced values like:
+
+- `pbmc_1k_v3.cluster_8`
+
+But `cluster_id` values in `cell_annotations.tsv` remain:
+
+- `cluster_8`
+
+So Sierra would receive a `group_id` that does not match the annotation schema, and scoping would collapse to zero rows.
+
+Observed log pattern in failed rerun tasks on 2026-05-02 before the prefix-normalization patch:
+
+- `Scoped annotations rows: 0`
+- `Whitelist barcodes after scoping: 0`
+- `WARNING: scoped whitelist is empty — writing empty TSV`
+
+Result in published outputs before the patch:
+
+- older non-prefixed cluster outputs remain populated
+- newer prefixed outputs are header-only
+
+## Recommendations
+
+### Contract recommendations
+
+- make `group_id` an explicit data field propagated in channels
+- do not reconstruct semantic identifiers from filenames
+- keep `library_id` and `group_id` orthogonal
+
+### Workflow recommendations
+
+1. Change `GROUPED_RECONSTRUCTION` or `GROUPED_BAM_GENERATION` to emit tuples containing explicit `group_id`.
+2. Keep the current `APA_CORE` prefix normalization only as a compatibility bridge.
+3. Keep filename prefixing for collision resistance, but treat it as presentation only.
+
+### Validation recommendations
+
+- add a pre-Sierra assertion that scoped annotations are non-empty for every emitted grouped BAM
+- add a regression test where:
+  - two libraries share barcode values
+  - grouped BAM filenames are prefixed
+  - Sierra cluster scoping still succeeds
+- add a post-run report counting header-only Sierra outputs by `library_id` and `group_level`
+
+### UX and debugging recommendations
+
+- retain the H5AD PCA/UMAP publication in `labels/`
+- add a compact `sierra_scope_summary.tsv` with:
+  - `library_id`
+  - `group_level`
+  - `group_id`
+  - `scoped_annotation_rows`
+  - `sampled_cb_tags`
+  - `output_rows`
+- include a short warning in the final report when duplicate-style Sierra outputs exist for the same logical group
+
+## Summary
+
+The workflow up to `SIERRA_QUANT` is now much more explicit and sample-aware than before the issue #10 work. The main residual fragility is that `group_id` is still inferred from a filename; the new prefix-normalization patch makes that safe for now, but explicit identifier propagation would still be a cleaner contract.
+
+Once that identifier propagation is made explicit, the sample-level STARsolo strategy should extend cleanly into Sierra for both `cluster` and `cell_type` groupings.

--- a/modules/local/alignment/starsolo_align_sc/main.nf
+++ b/modules/local/alignment/starsolo_align_sc/main.nf
@@ -1,5 +1,5 @@
 process STARSOLO_ALIGN_SC {
-    tag "$meta.library_id"
+    tag "$meta.sample_id"
     label 'process_high'
 
     conda "${projectDir}/envs/alignment.yml"
@@ -11,7 +11,7 @@ process STARSOLO_ALIGN_SC {
     publishDir "${params.outdir}/provenance", mode: params.publish_dir_mode, pattern: "*.alignment_manifest.tsv"
 
     input:
-    tuple val(meta), path(reads), path(whitelist), path(star_index), path(gtf), val(protocol_mode)
+    tuple val(meta), path(read1s), path(read2s), path(whitelist), path(star_index), path(gtf), val(protocol_mode)
 
     output:
     tuple val(meta), path("${meta.library_id}.Aligned.sortedByCoord.out.bam"), path("${meta.library_id}.Aligned.sortedByCoord.out.bam.bai"), emit: bam_bundle
@@ -23,7 +23,9 @@ process STARSOLO_ALIGN_SC {
     script:
     def whitelistArg = whitelist.name == 'NO_FILE' ? '--soloCBwhitelist None' : "--soloCBwhitelist ${whitelist}"
     def warning = protocol_mode == '10x_5p' ? "echo 'WARNING: guarded 10x 5p support is enabled; APA outputs are descriptive-first.' >&2" : ''
-    def readFilesCmd = reads[0].name.endsWith('.gz') ? '--readFilesCommand zcat' : ''
+    def readFilesCmd = read1s[0].name.endsWith('.gz') ? '--readFilesCommand zcat' : ''
+    def read1Arg = read1s.collect { it.toString() }.join(',')
+    def read2Arg = read2s.collect { it.toString() }.join(',')
     // STARsolo single-cell params derived from protocol_mode.
     // ext.args is not reliably propagated in Nextflow 25.x when multiple withName
     // selectors exist across config files, so critical params are hardcoded here.
@@ -38,55 +40,55 @@ process STARSOLO_ALIGN_SC {
         STAR \\
             --genomeDir ${star_index} \\
             --sjdbGTFfile ${gtf} \\
-            --readFilesIn ${reads[1]} ${reads[0]} \\
+            --readFilesIn ${read2Arg} ${read1Arg} \\
             ${readFilesCmd} \\
             --runThreadN ${task.cpus} \\
             --outSAMtype BAM SortedByCoordinate \\
             --outSAMattributes NH HI nM AS CR UR CB UB GX GN sS sQ sM \\
             ${soloTypeArgs} \\
-            --outFileNamePrefix ${meta.library_id}. \\
+            --outFileNamePrefix ${meta.sample_id}. \\
             ${whitelistArg} \\
             ${task.ext.args ?: ''} && _star_ok=1
     fi
 
     # Fallback placeholders — only if STAR was absent or failed
-    mkdir -p ${meta.library_id}.Solo.out/Gene
+    mkdir -p ${meta.sample_id}.Solo.out/Gene
     if [[ \$_star_ok -eq 0 ]]; then
-        touch ${meta.library_id}.Log.final.out
-        touch ${meta.library_id}.Aligned.sortedByCoord.out.bam
-        echo "${meta.sample_id}-CELL001" > ${meta.library_id}.Solo.out/Gene/barcodes.tsv
-        touch ${meta.library_id}.Solo.out/Gene/matrix.mtx
-        touch ${meta.library_id}.Solo.out/Gene/features.tsv
+        touch ${meta.sample_id}.Log.final.out
+        touch ${meta.sample_id}.Aligned.sortedByCoord.out.bam
+        echo "${meta.sample_id}-CELL001" > ${meta.sample_id}.Solo.out/Gene/barcodes.tsv
+        touch ${meta.sample_id}.Solo.out/Gene/matrix.mtx
+        touch ${meta.sample_id}.Solo.out/Gene/features.tsv
     fi
 
-    if command -v samtools >/dev/null 2>&1 && [[ -s ${meta.library_id}.Aligned.sortedByCoord.out.bam ]]; then
-        samtools index ${meta.library_id}.Aligned.sortedByCoord.out.bam
+    if command -v samtools >/dev/null 2>&1 && [[ -s ${meta.sample_id}.Aligned.sortedByCoord.out.bam ]]; then
+        samtools index ${meta.sample_id}.Aligned.sortedByCoord.out.bam
     else
-        touch ${meta.library_id}.Aligned.sortedByCoord.out.bam.bai
+        touch ${meta.sample_id}.Aligned.sortedByCoord.out.bam.bai
     fi
 
     python ${projectDir}/bin/extract_barcode_registry.py \\
-        --solo-dir ${meta.library_id}.Solo.out \\
+        --solo-dir ${meta.sample_id}.Solo.out \\
         --sample ${meta.sample_id} \\
-        --library ${meta.library_id} \\
-        --out ${meta.library_id}.barcode_registry.tsv
+        --library ${meta.sample_id} \\
+        --out ${meta.sample_id}.barcode_registry.tsv
 
     python ${projectDir}/bin/write_manifest.py \\
-        --input-table ${meta.library_id}.barcode_registry.tsv \\
-        --manifest-name ${meta.library_id}.alignment \\
-        --out ${meta.library_id}.alignment_manifest.tsv
+        --input-table ${meta.sample_id}.barcode_registry.tsv \\
+        --manifest-name ${meta.sample_id}.alignment \\
+        --out ${meta.sample_id}.alignment_manifest.tsv
     """
 
     stub:
     """
-    mkdir -p ${meta.library_id}.Solo.out/Gene
-    touch ${meta.library_id}.Aligned.sortedByCoord.out.bam
-    touch ${meta.library_id}.Aligned.sortedByCoord.out.bam.bai
-    touch ${meta.library_id}.Log.final.out
-    echo "${meta.library_id}-CELL001" > ${meta.library_id}.Solo.out/Gene/barcodes.tsv
-    touch ${meta.library_id}.Solo.out/Gene/matrix.mtx
-    touch ${meta.library_id}.Solo.out/Gene/features.tsv
-    printf "sample_id\\tlibrary_id\\tbarcode_raw\\tbarcode_corrected\\tsource\\n${meta.sample_id}\\t${meta.library_id}\\t${meta.library_id}-CELL001\\t${meta.library_id}-CELL001\\tstub\\n" > ${meta.library_id}.barcode_registry.tsv
-    printf "manifest_name\\tinput_table\\trows\\n${meta.library_id}.alignment\\t${meta.library_id}.barcode_registry.tsv\\t1\\n" > ${meta.library_id}.alignment_manifest.tsv
+    mkdir -p ${meta.sample_id}.Solo.out/Gene
+    touch ${meta.sample_id}.Aligned.sortedByCoord.out.bam
+    touch ${meta.sample_id}.Aligned.sortedByCoord.out.bam.bai
+    touch ${meta.sample_id}.Log.final.out
+    echo "${meta.sample_id}-CELL001" > ${meta.sample_id}.Solo.out/Gene/barcodes.tsv
+    touch ${meta.sample_id}.Solo.out/Gene/matrix.mtx
+    touch ${meta.sample_id}.Solo.out/Gene/features.tsv
+    printf "sample_id\\tlibrary_id\\tbarcode_raw\\tbarcode_corrected\\tsource\\n${meta.sample_id}\\t${meta.sample_id}\\t${meta.sample_id}-CELL001\\t${meta.sample_id}-CELL001\\tstub\\n" > ${meta.sample_id}.barcode_registry.tsv
+    printf "manifest_name\\tinput_table\\trows\\n${meta.sample_id}.alignment\\t${meta.sample_id}.barcode_registry.tsv\\t1\\n" > ${meta.sample_id}.alignment_manifest.tsv
     """
 }

--- a/modules/local/bam/bam_barcode_filter/main.nf
+++ b/modules/local/bam/bam_barcode_filter/main.nf
@@ -22,6 +22,8 @@ process BAM_BARCODE_FILTER {
     python ${projectDir}/bin/filter_bam_by_barcodes.py \\
         --bam            ${bam} \\
         --annotations    ${cell_annotations} \\
+        --sample-id      ${meta.sample_id} \\
+        --library-id     ${meta.library_id} \\
         --out-bam        ${meta.library_id}.filtered.bam \\
         --out-stats      ${meta.library_id}.barcode_filter_stats.tsv
 

--- a/modules/local/clustering/scanpy_cluster_sc/main.nf
+++ b/modules/local/clustering/scanpy_cluster_sc/main.nf
@@ -8,6 +8,7 @@ process SCANPY_CLUSTER_SC {
     publishDir "${params.outdir}/labels", mode: params.publish_dir_mode, pattern: "*.cell_annotations.tsv"
     publishDir "${params.outdir}/labels", mode: params.publish_dir_mode, pattern: "*.cluster_report.tsv"
     publishDir "${params.outdir}/labels", mode: params.publish_dir_mode, pattern: "*.clustered.h5ad"
+    publishDir "${params.outdir}/labels", mode: params.publish_dir_mode, pattern: "*.clustered.*.png"
 
     input:
     tuple val(meta), path(matrix_dir), path(cell_metadata), val(enable_internal_clustering), path(celltypist_model, stageAs: 'celltypist_model_input'), path(reference_h5ad, stageAs: 'reference_h5ad_input'), val(reference_label_col)
@@ -16,6 +17,7 @@ process SCANPY_CLUSTER_SC {
     tuple val(meta), path("${meta.library_id}.cell_annotations.tsv"), emit: cell_annotations
     tuple val(meta), path("${meta.library_id}.cluster_report.tsv"), emit: report
     tuple val(meta), path("${meta.library_id}.clustered.h5ad"), emit: h5ad
+    tuple val(meta), path("${meta.library_id}.clustered.*.png"), optional: true, emit: embedding_plots
 
     script:
     def ct_model_arg = (celltypist_model  && celltypist_model.name  != 'NO_FILE') ? "--celltypist-model celltypist_model_input"   : ''
@@ -35,13 +37,16 @@ process SCANPY_CLUSTER_SC {
         ${ref_col_arg} \\
         --out-annotations ${meta.library_id}.cell_annotations.tsv \\
         --out-report ${meta.library_id}.cluster_report.tsv \\
-        --out-h5ad ${meta.library_id}.clustered.h5ad
+        --out-h5ad ${meta.library_id}.clustered.h5ad \\
+        --out-plot-prefix ${meta.library_id}.clustered
     """
 
     stub:
     """
-    printf "sample_id\\tbarcode_raw\\tbarcode_corrected\\tcell_id\\tcluster_id\\tcell_type\\tcondition\\tbatch\\tlabel_source\\n${meta.sample_id}\\t${meta.library_id}-CELL001\\t${meta.library_id}-CELL001\\t${meta.sample_id}:${meta.library_id}-CELL001\\t${meta.library_id.contains('L001') ? 'cluster_1' : 'cluster_2'}\\tunlabeled\\t\\t\\tstub\\n" > ${meta.library_id}.cell_annotations.tsv
+    printf "sample_id\\tlibrary_id\\tbarcode_raw\\tbarcode_corrected\\tcell_id\\tcluster_id\\tcell_type\\tcondition\\tbatch\\tlabel_source\\n${meta.sample_id}\\t${meta.library_id}\\t${meta.library_id}-CELL001\\t${meta.library_id}-CELL001\\t${meta.sample_id}:${meta.library_id}:${meta.library_id}-CELL001\\t${meta.library_id.contains('L001') ? 'cluster_1' : 'cluster_2'}\\tunlabeled\\t\\t\\tstub\\n" > ${meta.library_id}.cell_annotations.tsv
     printf "sample_id\\tlibrary_id\\tn_cells\\tclustering_mode\\n${meta.sample_id}\\t${meta.library_id}\\t1\\tstub\\n" > ${meta.library_id}.cluster_report.tsv
     echo "{}" > ${meta.library_id}.clustered.h5ad
+    touch ${meta.library_id}.clustered.pca.png
+    touch ${meta.library_id}.clustered.umap.png
     """
 }

--- a/modules/local/grouping/build_group_map/main.nf
+++ b/modules/local/grouping/build_group_map/main.nf
@@ -29,17 +29,17 @@ process BUILD_GROUP_MAP {
 
     stub:
     """
-    printf "sample_id\\tbarcode_raw\\tbarcode_corrected\\tcell_id\\tcluster_id\\tcell_type\\tcondition\\tbatch\\tlabel_source\\n" \\
+    printf "sample_id\\tlibrary_id\\tbarcode_raw\\tbarcode_corrected\\tcell_id\\tcluster_id\\tcell_type\\tcondition\\tbatch\\tlabel_source\\n" \\
         > cell_annotations.tsv
-    printf "pbmc_1k_v3\\tpbmc_1k_v3_L001-CELL001\\tpbmc_1k_v3_L001-CELL001\\tpbmc_1k_v3:pbmc_1k_v3_L001-CELL001\\tcluster_1\\tunlabeled\\t\\t\\tstub\\n" \\
+    printf "pbmc_1k_v3\\tpbmc_1k_v3_L001\\tpbmc_1k_v3_L001-CELL001\\tpbmc_1k_v3_L001-CELL001\\tpbmc_1k_v3:pbmc_1k_v3_L001:pbmc_1k_v3_L001-CELL001\\tcluster_1\\tunlabeled\\t\\t\\tstub\\n" \\
         >> cell_annotations.tsv
-    printf "pbmc_1k_v3\\tpbmc_1k_v3_L002-CELL001\\tpbmc_1k_v3_L002-CELL001\\tpbmc_1k_v3:pbmc_1k_v3_L002-CELL001\\tcluster_2\\tunlabeled\\t\\t\\tstub\\n" \\
+    printf "pbmc_1k_v3\\tpbmc_1k_v3_L002\\tpbmc_1k_v3_L002-CELL001\\tpbmc_1k_v3_L002-CELL001\\tpbmc_1k_v3:pbmc_1k_v3_L002:pbmc_1k_v3_L002-CELL001\\tcluster_2\\tunlabeled\\t\\t\\tstub\\n" \\
         >> cell_annotations.tsv
-    printf "sample_id\\tbarcode_corrected\\tgroup_level\\tgroup_id\\n" \\
+    printf "sample_id\\tlibrary_id\\tbarcode_corrected\\tgroup_level\\tgroup_id\\n" \\
         > group_map.tsv
-    printf "pbmc_1k_v3\\tpbmc_1k_v3_L001-CELL001\\tcluster\\tcluster_1\\n" \\
+    printf "pbmc_1k_v3\\tpbmc_1k_v3_L001\\tpbmc_1k_v3_L001-CELL001\\tcluster\\tcluster_1\\n" \\
         >> group_map.tsv
-    printf "pbmc_1k_v3\\tpbmc_1k_v3_L002-CELL001\\tcluster\\tcluster_2\\n" \\
+    printf "pbmc_1k_v3\\tpbmc_1k_v3_L002\\tpbmc_1k_v3_L002-CELL001\\tcluster\\tcluster_2\\n" \\
         >> group_map.tsv
     printf "group_level\\tgroup_id\\tn_barcodes\\n" \\
         > group_summary.tsv

--- a/modules/local/grouping/grouped_bam_generation/main.nf
+++ b/modules/local/grouping/grouped_bam_generation/main.nf
@@ -23,6 +23,7 @@ process GROUPED_BAM_GENERATION {
         --bam           ${filtered_bam} \\
         --group-map     ${group_map} \\
         --sample-id     ${meta.sample_id} \\
+        --library-id    ${meta.library_id} \\
         --group-level   ${group_level} \\
         --out-dir       . \\
         --out-manifest  ${meta.library_id}.${group_level}.grouping_manifest.tsv

--- a/modules/local/grouping/write_group_bams/main.nf
+++ b/modules/local/grouping/write_group_bams/main.nf
@@ -19,6 +19,7 @@ process WRITE_GROUP_BAMS {
     python ${projectDir}/bin/write_group_bams.py \\
         --group-map ${group_map} \\
         --sample-id ${meta.sample_id} \\
+        --library-id ${meta.library_id} \\
         --out-dir ${meta.library_id}.group_bams \\
         --out-manifest ${meta.library_id}.group_bams_manifest.tsv
     """

--- a/modules/local/metadata/harmonize_cell_metadata/main.nf
+++ b/modules/local/metadata/harmonize_cell_metadata/main.nf
@@ -29,7 +29,7 @@ process HARMONIZE_CELL_METADATA {
 
     stub:
     """
-    printf "sample_id\\tbarcode_raw\\tbarcode_corrected\\tcell_id\\tcluster_id\\tcell_type\\tcondition\\tbatch\\tlabel_source\\n" > cell_metadata.harmonized.tsv
+    printf "sample_id\\tlibrary_id\\tbarcode_raw\\tbarcode_corrected\\tcell_id\\tcluster_id\\tcell_type\\tcondition\\tbatch\\tlabel_source\\n" > cell_metadata.harmonized.tsv
     echo "{}" > cell_metadata_manifest.json
     """
 }

--- a/modules/local/reference/prepare_reference_bundle/main.nf
+++ b/modules/local/reference/prepare_reference_bundle/main.nf
@@ -36,7 +36,12 @@ process PREPARE_REFERENCE_BUNDLE {
         --out-manifest reference_manifest.json
 
     mkdir -p star_index
-    if command -v STAR >/dev/null 2>&1; then
+    if [[ -n "${params.prebuilt_star_index}" && -d "${params.prebuilt_star_index}" ]]; then
+        # Hard-link the pre-built index into the work dir — zero extra disk space,
+        # instantaneous, and produces content-identical files so downstream
+        # process cache hashes remain stable.
+        cp -rl "${params.prebuilt_star_index}/." star_index/
+    elif command -v STAR >/dev/null 2>&1; then
         STAR \\
             --runMode genomeGenerate \\
             --runThreadN ${task.cpus} \\

--- a/modules/local/reference/prepare_reference_bundle/main.nf
+++ b/modules/local/reference/prepare_reference_bundle/main.nf
@@ -37,10 +37,17 @@ process PREPARE_REFERENCE_BUNDLE {
 
     mkdir -p star_index
     if [[ -n "${params.prebuilt_star_index}" && -d "${params.prebuilt_star_index}" ]]; then
-        # Hard-link the pre-built index into the work dir — zero extra disk space,
-        # instantaneous, and produces content-identical files so downstream
-        # process cache hashes remain stable.
-        cp -rl "${params.prebuilt_star_index}/." star_index/
+        # Try hard-linking first (zero disk space, instantaneous, and produces
+        # content-identical files so downstream cache hashes remain stable).
+        # Hard links fail when the source and destination are on different
+        # filesystems, so fall back to a regular copy in that case.
+        if cp -rl "${params.prebuilt_star_index}/." star_index/ 2>/dev/null; then
+            echo "Prebuilt STAR index staged via hard-links."
+        else
+            echo "Hard-link staging failed (likely cross-device); falling back to regular copy." >&2
+            cp -r "${params.prebuilt_star_index}/." star_index/ || \
+                { echo "ERROR: Failed to stage prebuilt STAR index from '${params.prebuilt_star_index}'." >&2; exit 1; }
+        fi
     elif command -v STAR >/dev/null 2>&1; then
         STAR \\
             --runMode genomeGenerate \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,6 +48,13 @@ params {
     apa_model_type                    = 'random_forest'  // 'random_forest'|'xgboost'|'logistic_regression'
     enable_single_cell_apa_projection = false    // project group APA scores back to single cells
 
+    // ── Pre-built STAR genome index ────────────────────────────────────────────
+    // Path to an existing STAR genome directory (produced by STAR --runMode genomeGenerate).
+    // When set, PREPARE_REFERENCE_BUNDLE skips genome generation and hard-links the index
+    // into the process work dir — effectively free in time and disk space.
+    // Leave null to generate the index from genome_fasta + gtf (default).
+    prebuilt_star_index = null
+
     // ── Container / Apptainer paths ───────────────────────────────────────────
     // Set to the directory holding pre-built scpolaseq-*.sif files.
     // Build them once with: bash containers/build.sh [--cache-dir <dir>]

--- a/subworkflows/apa_core.nf
+++ b/subworkflows/apa_core.nf
@@ -122,6 +122,10 @@ workflow APA_CORE {
                 def bai_list = (bais instanceof List) ? bais : [bais]
                 [bam_list, bai_list].transpose().collect { bam, bai ->
                     def group_id = bam.baseName.replaceAll(/\.grouped(\.bam)?$/, '')
+                    def prefix = meta.library_id ? "${meta.library_id}." : ''
+                    if (prefix && group_id.startsWith(prefix)) {
+                        group_id = group_id.substring(prefix.length())
+                    }
                     tuple(meta, group_level, group_id, bam, bai)
                 }
             }

--- a/subworkflows/local/alignment_or_import/main.nf
+++ b/subworkflows/local/alignment_or_import/main.nf
@@ -30,6 +30,11 @@ workflow ALIGN_OR_IMPORT_SC {
         .splitCsv(header: true)
         .map { row ->
             def sampleId = normalize(row.sample_id)
+            if (!sampleId) {
+                throw new IllegalArgumentException(
+                    "A samplesheet row has a missing or blank sample_id. All rows must have a non-empty sample_id. Row: ${row}"
+                )
+            }
             def fastqR1 = normalize(row.fastq_r1)
             def fastqR2 = normalize(row.fastq_r2)
             def bamPath = normalize(row.bam)

--- a/subworkflows/local/alignment_or_import/main.nf
+++ b/subworkflows/local/alignment_or_import/main.nf
@@ -15,48 +15,104 @@ workflow ALIGN_OR_IMPORT_SC {
     }
 
     def nofile = file("${projectDir}/assets/NO_FILE")
+    def normalize = { value -> value ? value.toString().trim() : '' }
+    def distinctOrThrow = { sampleId, entries, key, fallback = '' ->
+        def values = entries.collect { entry -> normalize(entry[key]) }.findAll { it }.unique()
+        if (values.size() > 1) {
+            throw new IllegalArgumentException(
+                "Sample '${sampleId}' has conflicting ${key} values across source libraries: ${values.join(', ')}"
+            )
+        }
+        values ? values[0] : fallback
+    }
 
     samplesheet
         .splitCsv(header: true)
         .map { row ->
+            def sampleId = normalize(row.sample_id)
+            def fastqR1 = normalize(row.fastq_r1)
+            def fastqR2 = normalize(row.fastq_r2)
+            def bamPath = normalize(row.bam)
+            def matrixPath = normalize(row.matrix_path)
+            def whitelistPath = normalize(row.barcode_whitelist)
+            tuple(
+                sampleId,
+                [
+                    sample_id        : sampleId,
+                    source_library_id: normalize(row.library_id),
+                    protocol         : normalize(row.protocol) ?: protocol_mode,
+                    chemistry        : normalize(row.chemistry),
+                    condition        : normalize(row.condition),
+                    replicate_id     : normalize(row.replicate_id) ?: sampleId,
+                    fastq_r1         : fastqR1 ? file(fastqR1, checkIfExists: true) : null,
+                    fastq_r2         : fastqR2 ? file(fastqR2, checkIfExists: true) : null,
+                    bam              : bamPath ? file(bamPath, checkIfExists: true) : nofile,
+                    matrix           : matrixPath ? file(matrixPath, checkIfExists: true) : nofile,
+                    whitelist        : whitelistPath ? file(whitelistPath, checkIfExists: true) : nofile,
+                ]
+            )
+        }
+        .groupTuple()
+        .map { sampleId, entries ->
+            def read1s = entries.collect { it.fastq_r1 }.findAll { it != null }
+            def read2s = entries.collect { it.fastq_r2 }.findAll { it != null }
+            if (read1s.size() != read2s.size()) {
+                throw new IllegalArgumentException(
+                    "Sample '${sampleId}' has mismatched FASTQ mates after sample-level grouping: R1=${read1s.size()} R2=${read2s.size()}"
+                )
+            }
+
+            def bamInputs = entries.collect { it.bam }.findAll { it != null && it.name != 'NO_FILE' }
+            def matrixInputs = entries.collect { it.matrix }.findAll { it != null && it.name != 'NO_FILE' }
+            def whitelistCandidates = entries.collect { it.whitelist }.findAll { it != null && it.name != 'NO_FILE' }
+            def whitelistPaths = whitelistCandidates.collect { it.toString() }.unique()
+            if (whitelistPaths.size() > 1) {
+                throw new IllegalArgumentException(
+                    "Sample '${sampleId}' has multiple barcode whitelist files across source libraries: ${whitelistPaths.join(', ')}"
+                )
+            }
+
+            def sourceLibraries = entries.collect { normalize(it.source_library_id) }.findAll { it }.unique().sort()
             def meta = [
-                sample_id   : row.sample_id,
-                library_id  : row.library_id,
-                protocol    : row.protocol ?: protocol_mode,
-                chemistry   : row.chemistry,
-                condition   : row.condition,
-                replicate_id: row.replicate_id ?: row.sample_id,
+                sample_id         : sampleId,
+                library_id        : sampleId,
+                source_library_ids: sourceLibraries.join(','),
+                protocol          : distinctOrThrow(sampleId, entries, 'protocol', protocol_mode),
+                chemistry         : distinctOrThrow(sampleId, entries, 'chemistry', ''),
+                condition         : distinctOrThrow(sampleId, entries, 'condition', ''),
+                replicate_id      : distinctOrThrow(sampleId, entries, 'replicate_id', sampleId),
             ]
-            def reads = []
-            if (row.fastq_r1) {
-                reads << file(row.fastq_r1, checkIfExists: true)
-            }
-            if (row.fastq_r2) {
-                reads << file(row.fastq_r2, checkIfExists: true)
-            }
-            def bam = row.bam ? file(row.bam, checkIfExists: true) : nofile
-            def matrix = row.matrix_path ? file(row.matrix_path, checkIfExists: true) : nofile
-            def whitelist = row.barcode_whitelist ? file(row.barcode_whitelist, checkIfExists: true) : nofile
-            tuple(meta, reads, bam, matrix, whitelist)
+
+            tuple(meta, read1s, read2s, bamInputs, matrixInputs, whitelistCandidates ? whitelistCandidates[0] : nofile)
         }
         .set { ch_rows }
 
     ch_rows
-        .filter { meta, reads, bam, matrix, whitelist ->
-            run_mode == 'full' && reads.size() >= 2
+        .filter { meta, read1s, read2s, bamInputs, matrixInputs, whitelist ->
+            run_mode == 'full' && read1s.size() >= 1 && read2s.size() >= 1
         }
         .combine(reference_bundle)
-        .map { meta, reads, bam, matrix, whitelist, reference_meta, star_index, gtf, fasta, chrom_sizes, terminal_exons, atlas, blacklist ->
-            tuple(meta, reads, whitelist, star_index, gtf, meta.protocol)
+        .map { meta, read1s, read2s, bamInputs, matrixInputs, whitelist, reference_meta, star_index, gtf, fasta, chrom_sizes, terminal_exons, atlas, blacklist ->
+            tuple(meta, read1s, read2s, whitelist, star_index, gtf, meta.protocol)
         }
         .set { ch_fastq }
 
     ch_rows
-        .filter { meta, reads, bam, matrix, whitelist ->
-            bam.name != 'NO_FILE' && (run_mode in ['from_bam', 'feedback'] || reads.size() == 0)
+        .filter { meta, read1s, read2s, bamInputs, matrixInputs, whitelist ->
+            bamInputs.size() >= 1 && (run_mode in ['from_bam', 'feedback'] || (read1s.size() == 0 && read2s.size() == 0))
         }
-        .map { meta, reads, bam, matrix, whitelist ->
-            tuple(meta, bam, matrix, whitelist)
+        .map { meta, read1s, read2s, bamInputs, matrixInputs, whitelist ->
+            if (bamInputs.size() != 1) {
+                throw new IllegalArgumentException(
+                    "Sample-level BAM import currently expects exactly one BAM per sample; sample '${meta.sample_id}' received ${bamInputs.size()}"
+                )
+            }
+            if (matrixInputs.size() > 1) {
+                throw new IllegalArgumentException(
+                    "Sample-level BAM import currently expects at most one matrix bundle per sample; sample '${meta.sample_id}' received ${matrixInputs.size()}"
+                )
+            }
+            tuple(meta, bamInputs[0], matrixInputs ? matrixInputs[0] : nofile, whitelist)
         }
         .set { ch_bam }
 

--- a/tests/test_issue10_barcode_identity.py
+++ b/tests/test_issue10_barcode_identity.py
@@ -1,0 +1,309 @@
+import csv
+import importlib.util
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(relative_path: str, module_name: str):
+    module_path = REPO_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_tsv(path: Path, fieldnames, rows) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def read_tsv(path: Path):
+    with path.open("r", newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle, delimiter="\t"))
+
+
+class DummyAdata:
+    def __init__(self, obs_names):
+        self.obs_names = list(obs_names)
+        self.obs = {}
+        self.obsm = {}
+
+    @property
+    def n_obs(self):
+        return len(self.obs_names)
+
+
+def test_extract_barcode_registry_preserves_starsolo_suffixes(tmp_path):
+    extract = load_module("bin/extract_barcode_registry.py", "extract_barcode_registry")
+    solo_dir = tmp_path / "Solo.out" / "Gene" / "filtered"
+    solo_dir.mkdir(parents=True)
+    (solo_dir / "barcodes.tsv").write_text("AAACCCAAGGAGAGTA-1\nTTTGTTTCCCAAATCG-2\n", encoding="utf-8")
+
+    rows = extract.extract_from_solo(tmp_path / "Solo.out", "pbmc_1k_v3", "pbmc_1k_v3_L002")
+
+    assert [row["barcode_raw"] for row in rows] == ["AAACCCAAGGAGAGTA-1", "TTTGTTTCCCAAATCG-2"]
+    assert [row["barcode_corrected"] for row in rows] == ["AAACCCAAGGAGAGTA-1", "TTTGTTTCCCAAATCG-2"]
+    assert {row["library_id"] for row in rows} == {"pbmc_1k_v3_L002"}
+
+
+def test_scanpy_cluster_outputs_library_aware_annotations_and_reversible_ids(tmp_path):
+    scanpy_cluster = load_module("bin/scanpy_cluster_sc.py", "scanpy_cluster_sc")
+
+    matrix_dir = tmp_path / "matrix" / "filtered"
+    matrix_dir.mkdir(parents=True)
+    (matrix_dir / "barcodes.tsv").write_text("AAAC-1\nTTTG-1\n", encoding="utf-8")
+
+    metadata_path = tmp_path / "cell_metadata.tsv"
+    metadata_path.write_text("", encoding="utf-8")
+    out_annotations = tmp_path / "annotations.tsv"
+    out_report = tmp_path / "report.tsv"
+    out_h5ad = tmp_path / "clustered.h5ad"
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "bin/scanpy_cluster_sc.py"),
+            "--matrix-dir",
+            str(tmp_path / "matrix"),
+            "--cell-metadata",
+            str(metadata_path),
+            "--sample-id",
+            "pbmc_1k_v3",
+            "--library-id",
+            "pbmc_1k_v3_L002",
+            "--enable-internal-clustering",
+            "false",
+            "--out-annotations",
+            str(out_annotations),
+            "--out-report",
+            str(out_report),
+            "--out-h5ad",
+            str(out_h5ad),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+    rows = read_tsv(out_annotations)
+    assert rows[0]["library_id"] == "pbmc_1k_v3_L002"
+    assert rows[0]["barcode_raw"] == "AAAC-1"
+    assert rows[0]["barcode_corrected"] == "AAAC-1"
+    assert rows[0]["cell_id"] == "pbmc_1k_v3:pbmc_1k_v3_L002:AAAC-1"
+
+    dummy = DummyAdata(["AAAC-1", "TTTG-1"])
+    scanpy_cluster.annotate_adata_obs(dummy, "pbmc_1k_v3", "pbmc_1k_v3_L002")
+    assert dummy.obs["sample_id"] == ["pbmc_1k_v3", "pbmc_1k_v3"]
+    assert dummy.obs["library_id"] == ["pbmc_1k_v3_L002", "pbmc_1k_v3_L002"]
+    assert dummy.obs["barcode_raw"] == ["AAAC-1", "TTTG-1"]
+    assert dummy.obs["barcode_corrected"] == ["AAAC-1", "TTTG-1"]
+    assert dummy.obs["cell_id"] == [
+        "pbmc_1k_v3:pbmc_1k_v3_L002:AAAC-1",
+        "pbmc_1k_v3:pbmc_1k_v3_L002:TTTG-1",
+    ]
+    assert dummy.obs_names == dummy.obs["cell_id"]
+
+
+def test_build_group_map_keeps_library_id_for_shared_barcodes(tmp_path):
+    annotation_fields = [
+        "sample_id",
+        "library_id",
+        "barcode_raw",
+        "barcode_corrected",
+        "cell_id",
+        "cluster_id",
+        "cell_type",
+        "condition",
+        "batch",
+        "label_source",
+    ]
+    annotation_one = tmp_path / "L001.cell_annotations.tsv"
+    annotation_two = tmp_path / "L002.cell_annotations.tsv"
+    write_tsv(
+        annotation_one,
+        annotation_fields,
+        [
+            {
+                "sample_id": "pbmc_1k_v3",
+                "library_id": "pbmc_1k_v3_L001",
+                "barcode_raw": "AAAC-1",
+                "barcode_corrected": "AAAC-1",
+                "cell_id": "pbmc_1k_v3:pbmc_1k_v3_L001:AAAC-1",
+                "cluster_id": "cluster_1",
+                "cell_type": "T",
+                "condition": "",
+                "batch": "",
+                "label_source": "unit_test",
+            }
+        ],
+    )
+    write_tsv(
+        annotation_two,
+        annotation_fields,
+        [
+            {
+                "sample_id": "pbmc_1k_v3",
+                "library_id": "pbmc_1k_v3_L002",
+                "barcode_raw": "AAAC-1",
+                "barcode_corrected": "AAAC-1",
+                "cell_id": "pbmc_1k_v3:pbmc_1k_v3_L002:AAAC-1",
+                "cluster_id": "cluster_2",
+                "cell_type": "B",
+                "condition": "",
+                "batch": "",
+                "label_source": "unit_test",
+            }
+        ],
+    )
+
+    out_annotations = tmp_path / "cell_annotations.tsv"
+    out_group_map = tmp_path / "group_map.tsv"
+    out_group_summary = tmp_path / "group_summary.tsv"
+    subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "bin/build_group_map.py"),
+            "--annotation-files",
+            str(annotation_one),
+            str(annotation_two),
+            "--grouping-levels",
+            "cell,cluster",
+            "--out-cell-annotations",
+            str(out_annotations),
+            "--out-group-map",
+            str(out_group_map),
+            "--out-group-summary",
+            str(out_group_summary),
+        ],
+        check=True,
+        cwd=REPO_ROOT,
+    )
+
+    annotation_rows = read_tsv(out_annotations)
+    assert set(annotation_rows[0].keys()) == set(annotation_fields)
+    assert {row["library_id"] for row in annotation_rows} == {"pbmc_1k_v3_L001", "pbmc_1k_v3_L002"}
+
+    group_rows = read_tsv(out_group_map)
+    assert set(group_rows[0].keys()) == {"sample_id", "library_id", "barcode_corrected", "group_level", "group_id"}
+    assert {
+        (row["library_id"], row["group_level"], row["group_id"])
+        for row in group_rows
+    } == {
+        ("pbmc_1k_v3_L001", "cell", "pbmc_1k_v3:pbmc_1k_v3_L001:AAAC-1"),
+        ("pbmc_1k_v3_L001", "cluster", "cluster_1"),
+        ("pbmc_1k_v3_L002", "cell", "pbmc_1k_v3:pbmc_1k_v3_L002:AAAC-1"),
+        ("pbmc_1k_v3_L002", "cluster", "cluster_2"),
+    }
+
+
+def test_grouped_3prime_coverage_scopes_shared_barcodes_by_library(tmp_path):
+    grouped_coverage = load_module("bin/grouped_3prime_coverage.py", "grouped_3prime_coverage")
+    group_map_path = tmp_path / "group_map.tsv"
+    barcode_registry_path = tmp_path / "barcode_registry.tsv"
+
+    write_tsv(
+        group_map_path,
+        ["sample_id", "library_id", "barcode_corrected", "group_level", "group_id"],
+        [
+            {
+                "sample_id": "pbmc_1k_v3",
+                "library_id": "pbmc_1k_v3_L001",
+                "barcode_corrected": "AAAC-1",
+                "group_level": "cluster",
+                "group_id": "cluster_1",
+            },
+            {
+                "sample_id": "pbmc_1k_v3",
+                "library_id": "pbmc_1k_v3_L002",
+                "barcode_corrected": "AAAC-1",
+                "group_level": "cluster",
+                "group_id": "cluster_2",
+            },
+        ],
+    )
+    write_tsv(
+        barcode_registry_path,
+        ["sample_id", "library_id", "barcode_raw", "barcode_corrected", "source"],
+        [
+            {
+                "sample_id": "pbmc_1k_v3",
+                "library_id": "pbmc_1k_v3_L001",
+                "barcode_raw": "AAAC-1",
+                "barcode_corrected": "AAAC-1",
+                "source": "starsolo",
+            },
+            {
+                "sample_id": "pbmc_1k_v3",
+                "library_id": "pbmc_1k_v3_L002",
+                "barcode_raw": "AAAC-1",
+                "barcode_corrected": "AAAC-1",
+                "source": "starsolo",
+            },
+        ],
+    )
+
+    group_map = grouped_coverage.load_group_map(group_map_path, "pbmc_1k_v3", "pbmc_1k_v3_L001")
+    barcode_registry = grouped_coverage.load_barcode_registry(
+        barcode_registry_path,
+        "pbmc_1k_v3",
+        "pbmc_1k_v3_L001",
+    )
+    counts = grouped_coverage.fallback_counts(group_map, barcode_registry, [("chr1", 1000)])
+
+    assert group_map == {"AAAC-1": [("cluster", "cluster_1")]}
+    assert len(barcode_registry) == 1
+    assert {key[1] for key in counts} == {"cluster_1"}
+
+
+def test_scanpy_cluster_emits_embedding_plots_when_embeddings_exist(tmp_path):
+    scanpy_cluster = load_module("bin/scanpy_cluster_sc.py", "scanpy_cluster_sc_plots")
+    if importlib.util.find_spec("matplotlib") is None:
+        return
+
+    import numpy as np
+
+    dummy = DummyAdata(["AAAC-1", "TTTG-1"])
+    dummy.obsm["X_pca"] = np.array([[0.0, 1.0], [1.0, 0.0]])
+    dummy.obsm["X_umap"] = np.array([[0.2, 0.3], [0.8, 0.5]])
+    dummy.obs["cluster_id"] = ["cluster_1", "cluster_2"]
+
+    plot_prefix = tmp_path / "pbmc_1k_v3_L001.clustered"
+    scanpy_cluster.emit_embedding_plots(dummy, str(plot_prefix))
+
+    assert (tmp_path / "pbmc_1k_v3_L001.clustered.pca.png").exists()
+    assert (tmp_path / "pbmc_1k_v3_L001.clustered.umap.png").exists()
+
+
+def test_write_group_bams_names_outputs_with_library_prefix(tmp_path):
+    write_group_bams = load_module("bin/write_group_bams.py", "write_group_bams")
+    assert (
+        write_group_bams.grouped_bam_name("pbmc_1k_v3_L001", "cluster_1")
+        == "pbmc_1k_v3_L001.cluster_1.grouped.bam"
+    )
+    assert write_group_bams.grouped_bam_name(None, "cluster_1") == "cluster_1.grouped.bam"
+
+
+def run_all_tests() -> None:
+    test_functions = [
+        test_extract_barcode_registry_preserves_starsolo_suffixes,
+        test_scanpy_cluster_outputs_library_aware_annotations_and_reversible_ids,
+        test_build_group_map_keeps_library_id_for_shared_barcodes,
+        test_grouped_3prime_coverage_scopes_shared_barcodes_by_library,
+        test_scanpy_cluster_emits_embedding_plots_when_embeddings_exist,
+        test_write_group_bams_names_outputs_with_library_prefix,
+    ]
+    for test_function in test_functions:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            test_function(Path(tmpdir))
+    print(f"{len(test_functions)} tests passed")
+
+
+if __name__ == "__main__":
+    run_all_tests()

--- a/tests/test_issue10_barcode_identity.py
+++ b/tests/test_issue10_barcode_identity.py
@@ -290,6 +290,23 @@ def test_write_group_bams_names_outputs_with_library_prefix(tmp_path):
     assert write_group_bams.grouped_bam_name(None, "cluster_1") == "cluster_1.grouped.bam"
 
 
+def test_alignment_subworkflow_collapses_samplesheet_rows_by_sample_id(tmp_path):
+    del tmp_path
+    alignment_nf = (REPO_ROOT / "subworkflows" / "local" / "alignment_or_import" / "main.nf").read_text(
+        encoding="utf-8"
+    )
+    assert ".groupTuple()" in alignment_nf
+    assert "library_id        : sampleId" in alignment_nf
+    assert "source_library_ids" in alignment_nf
+
+
+def test_apa_core_normalizes_group_id_before_sierra(tmp_path):
+    del tmp_path
+    apa_core_nf = (REPO_ROOT / "subworkflows" / "apa_core.nf").read_text(encoding="utf-8")
+    assert "def prefix = meta.library_id ? \"${meta.library_id}.\" : ''" in apa_core_nf
+    assert "group_id.startsWith(prefix)" in apa_core_nf
+
+
 def run_all_tests() -> None:
     test_functions = [
         test_extract_barcode_registry_preserves_starsolo_suffixes,
@@ -298,6 +315,8 @@ def run_all_tests() -> None:
         test_grouped_3prime_coverage_scopes_shared_barcodes_by_library,
         test_scanpy_cluster_emits_embedding_plots_when_embeddings_exist,
         test_write_group_bams_names_outputs_with_library_prefix,
+        test_alignment_subworkflow_collapses_samplesheet_rows_by_sample_id,
+        test_apa_core_normalizes_group_id_before_sierra,
     ]
     for test_function in test_functions:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
This pull request implements a major refactor to shift the pipeline from a library-level to a sample-level analysis unit, starting from STARsolo alignment and propagating through all downstream modules, documentation, and outputs. The changes address longstanding barcode identity mismatches, unify sample handling, and improve the robustness and clarity of cell and group annotation logic. Additionally, the pull request documents the fixes and remaining issues related to barcode scoping and Sierra quantification, and updates resource allocations for better parallelism.

Key changes include:

**1. Pipeline-wide migration to sample-level scoping**  
- All alignment, annotation, grouping, and coverage outputs are now keyed by `sample_id` instead of `library_id`, with filenames, manifest fields, and directory structures updated accordingly. This ensures that multiple libraries/lanes for the same sample are merged prior to STARsolo and remain unified downstream. [[1]](diffhunk://#diff-dcb59ee90844d6426fafb8c0dab2dd17082285e61a8f34389c278939929efba0L2-R2) [[2]](diffhunk://#diff-dcb59ee90844d6426fafb8c0dab2dd17082285e61a8f34389c278939929efba0L41-R92) [[3]](diffhunk://#diff-3b979db8fe1a091621af10f24bf1c82d8640ceecb8a784a9bcb16d2a111b0db7L10-R42) [[4]](diffhunk://#diff-3b979db8fe1a091621af10f24bf1c82d8640ceecb8a784a9bcb16d2a111b0db7L39-R56) [[5]](diffhunk://#diff-b3244ad60ed8ebdb5e7573f78ddab39d5e9bfc3a34745859ae6d41becf7ed774L68-R72) [[6]](diffhunk://#diff-b3244ad60ed8ebdb5e7573f78ddab39d5e9bfc3a34745859ae6d41becf7ed774L85-R91) [[7]](diffhunk://#diff-b3244ad60ed8ebdb5e7573f78ddab39d5e9bfc3a34745859ae6d41becf7ed774R127-R134) [[8]](diffhunk://#diff-b3244ad60ed8ebdb5e7573f78ddab39d5e9bfc3a34745859ae6d41becf7ed774L176-R189)

**2. Barcode identity and annotation schema hardening**  
- Canonical barcode fields (`sample_id`, `library_id`, `barcode_raw`, `barcode_corrected`, `cell_id`) are now explicitly propagated in `cell_annotations.tsv`, H5AD files, and all relevant scripts and modules. The reversible `cell_id` format is enforced, and documentation is updated to reflect the new schema. [[1]](diffhunk://#diff-7401b9b613807792cafca57d2433f0dcc1a0a84589a83f05e2574f7910710410R1-R275) [[2]](diffhunk://#diff-3b979db8fe1a091621af10f24bf1c82d8640ceecb8a784a9bcb16d2a111b0db7L10-R42) [[3]](diffhunk://#diff-b3244ad60ed8ebdb5e7573f78ddab39d5e9bfc3a34745859ae6d41becf7ed774R127-R134)

**3. Grouping and Sierra quantification logic fixes**  
- Grouped BAM and Sierra quantification steps are updated to use the correct sample-aware group IDs and filenames, with logic patched to strip analysis prefixes and match annotation tables correctly. Documentation and recommendations for further stability and observability improvements are included. [[1]](diffhunk://#diff-7401b9b613807792cafca57d2433f0dcc1a0a84589a83f05e2574f7910710410R1-R275) [[2]](diffhunk://#diff-b3244ad60ed8ebdb5e7573f78ddab39d5e9bfc3a34745859ae6d41becf7ed774L176-R189)

**4. Resource allocation and config improvements**  
- Process resource allocations are tuned for better concurrency and efficiency, and a prebuilt STAR index parameter is introduced to speed up alignment. [[1]](diffhunk://#diff-735f79cb23c0b2ce4df6d1c0dc1046f265aa67e5bc818ab5ebabd0c45a44ffcfR22-R25) [[2]](diffhunk://#diff-735f79cb23c0b2ce4df6d1c0dc1046f265aa67e5bc818ab5ebabd0c45a44ffcfL100-R141)

**5. Documentation and module contract updates**  
- All relevant documentation (`docs/outputs.md`, `docs/module_contracts.md`, new activity summary) is updated to describe the new sample-level conventions, output structures, and canonical annotation schemas. [[1]](diffhunk://#diff-7401b9b613807792cafca57d2433f0dcc1a0a84589a83f05e2574f7910710410R1-R275) [[2]](diffhunk://#diff-3b979db8fe1a091621af10f24bf1c82d8640ceecb8a784a9bcb16d2a111b0db7L10-R42) [[3]](diffhunk://#diff-3b979db8fe1a091621af10f24bf1c82d8640ceecb8a784a9bcb16d2a111b0db7L39-R56) [[4]](diffhunk://#diff-b3244ad60ed8ebdb5e7573f78ddab39d5e9bfc3a34745859ae6d41becf7ed774L68-R72) [[5]](diffhunk://#diff-b3244ad60ed8ebdb5e7573f78ddab39d5e9bfc3a34745859ae6d41becf7ed774L85-R91) [[6]](diffhunk://#diff-b3244ad60ed8ebdb5e7573f78ddab39d5e9bfc3a34745859ae6d41becf7ed774R127-R134) [[7]](diffhunk://#diff-b3244ad60ed8ebdb5e7573f78ddab39d5e9bfc3a34745859ae6d41becf7ed774L176-R189)

These changes collectively resolve the major barcode scoping issues, unify the analysis unit, and lay the groundwork for improved stability and testability in future runs.